### PR TITLE
Add citation scraping control room UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
-# Adxsall
+# Citation Scraper Control Room
+
+The Citation Scraper Control Room is a browser-based workspace for composing article URLs, configuring scraping modes, extracting inline citations/footnotes, and validating the resulting references before exporting structured datasets.
+
+## Getting started
+
+1. Clone or download this repository.
+2. Open `index.html` in any modern browser (Chrome, Edge, Firefox, or Safari). No build step is required; all assets are static.
+
+## Workspace overview
+
+The interface is split into two columns:
+
+- **Configuration panels** (left) include URL composition tools, scraping mode toggles, section selection, and batch controls.
+- **Results panels** (right) display live previews, export utilities, and the validation/self-check summary.
+
+### Source URL & query parameters
+
+- Enter the base address of the page you want to scrape.
+- Add query parameters via the **Add parameter** button. Each row lets you specify a `key=value` pair; remove a row with the `×` button.
+- The composed URL preview updates automatically and can be opened in a new tab.
+
+### Quick link presets
+
+Use the “Sample journal article”, “Preprint landing page”, or “Policy brief” shortcuts to load example configurations. Presets populate the URL, recommended sections, and sample HTML so you can explore the toolkit immediately.
+
+### Scraping modes
+
+Toggle the scraping strategies you want to apply:
+
+- **Inline & footnotes** (always enabled) parses superscript references and footnotes.
+- **Simulate hover tooltips** inspects tooltip/aria attributes to capture hover-only citation text.
+- **Batch runner** indicates that you will run multiple sections in sequence.
+- **Save HTML snapshots** preserves section markup inside the result payload.
+
+At least one mode must remain active. The active modes are stored with each generated document and appear as badges in the preview.
+
+### Section selection
+
+- Choose which subsections of the article to capture. The defaults cover common scholarly headings.
+- Add custom selectors with `Title::CSS selector` (for example `Related Work::section#related-work`). The selector portion is optional; without it the scraper matches headings by text.
+- Select multiple sections to generate a separate document for each.
+
+### Source markup
+
+Paste the article’s HTML into the **Source markup** textarea. The scraper works entirely client-side, so providing markup is required for parsing inline citations and footnotes. Presets include sample HTML to experiment with.
+
+### Batch controls
+
+- **Start scraping** kicks off the section-by-section runner. A progress bar and activity log show the current status.
+- **Stop** requests cancellation after the current section finishes processing.
+- The activity log records informational, warning, and error messages for troubleshooting.
+
+## Previews & exports
+
+- Use the **Documents**, **Inline citations**, and **Footnotes** tabs to inspect results. Each section preview includes captured HTML, Markdown, and plain-text versions.
+- Export the dataset as JSON, Markdown, HTML, or BibTeX. Files include metadata (source URL, modes, timestamps) plus the normalized citation structures.
+- **Copy Markdown to clipboard** provides a quick summary for pasting into notes or reports.
+
+## Validation & self-check
+
+The validation panel verifies citation integrity for each generated document:
+
+- ✅ Sections with matching inline citations and footnotes show a green success pill.
+- ⚠️ Warnings enumerate issues such as inline references without footnotes, unreferenced footnotes, or missing citation numbers.
+- Section-level warnings (e.g., missing selectors) also appear in the panel.
+
+Use this feedback to repair markup before exporting.
+
+## Tips
+
+- Hover simulation uses tooltip, title, and aria-label attributes—ensure your markup exposes these attributes for accurate extraction.
+- You can re-run the scraper with adjusted sections or modes at any time; the most recent run replaces previous previews.
+- Combine exports: for example, download JSON for programmatic use and Markdown for human review.
+
+Enjoy the streamlined citation auditing workflow!

--- a/index.html
+++ b/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Citation Scraper Control Room</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="app-header__inner">
+        <div class="branding">
+          <span class="branding__mark" aria-hidden="true">⧉</span>
+          <div class="branding__copy">
+            <h1>Citation Scraper Control Room</h1>
+            <p>Compose scholarly URLs, collect citations, and validate references before exporting.</p>
+          </div>
+        </div>
+        <div class="header-actions">
+          <span class="version-pill" aria-label="Release channel">Prototype</span>
+        </div>
+      </div>
+    </header>
+
+    <main class="app-layout" aria-label="Scraper workspace">
+      <section class="panel panel--configuration" aria-label="Configuration panels">
+        <div class="card">
+          <header class="card__header">
+            <h2>Source URL</h2>
+            <p class="card__subtitle">Define the target you want to scrape and preview the fully composed address.</p>
+          </header>
+          <div class="form-grid">
+            <label class="form-field">
+              <span class="form-label">Base URL</span>
+              <input id="base-url" type="url" placeholder="https://journal.example.org/article" autocomplete="off" />
+            </label>
+            <div class="form-field form-field--stacked">
+              <span class="form-label">Query parameters</span>
+              <div id="query-params" class="param-list" aria-live="polite"></div>
+              <button id="add-param" type="button" class="button button--ghost">Add parameter</button>
+            </div>
+          </div>
+          <div class="url-preview" aria-live="polite">
+            <span class="url-preview__label">Composed URL</span>
+            <a id="composed-url" class="url-preview__link" href="#" target="_blank" rel="noopener">—</a>
+          </div>
+        </div>
+
+        <div class="card">
+          <header class="card__header">
+            <h2>Quick link presets</h2>
+            <p class="card__subtitle">Load example configurations to explore the toolkit faster.</p>
+          </header>
+          <div class="quick-links" role="group" aria-label="Quick link presets">
+            <button type="button" class="button button--chip" data-quick-link="sample-article">Sample journal article</button>
+            <button type="button" class="button button--chip" data-quick-link="preprint">Preprint landing page</button>
+            <button type="button" class="button button--chip" data-quick-link="policy">Policy brief</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <header class="card__header">
+            <h2>Scraping modes</h2>
+            <p class="card__subtitle">Toggle strategies that will be applied while parsing the article.</p>
+          </header>
+          <div class="mode-toggle" role="group" aria-label="Scraping modes">
+            <button type="button" class="toggle-button toggle-button--active" data-mode="inline-footnotes" aria-pressed="true">Inline &amp; footnotes</button>
+            <button type="button" class="toggle-button" data-mode="hover-tooltips" aria-pressed="false">Simulate hover tooltips</button>
+            <button type="button" class="toggle-button" data-mode="batch">Batch runner</button>
+            <button type="button" class="toggle-button" data-mode="snapshots">Save HTML snapshots</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <header class="card__header">
+            <h2>Section selection</h2>
+            <p class="card__subtitle">Choose which subsections to scrape. Add custom selectors with <code>Title::CSS selector</code>.</p>
+          </header>
+          <fieldset class="section-picker">
+            <legend class="sr-only">Available sections</legend>
+            <div id="section-list" class="section-list"></div>
+            <div class="section-picker__actions">
+              <label class="form-field form-field--inline">
+                <span class="form-label">Add custom section</span>
+                <input id="custom-section" type="text" placeholder="Discussion::section#discussion" autocomplete="off" />
+              </label>
+              <button id="add-section" type="button" class="button button--ghost">Add</button>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="card">
+          <header class="card__header">
+            <h2>Source markup</h2>
+            <p class="card__subtitle">Paste article HTML to drive citation extraction and validation.</p>
+          </header>
+          <textarea id="raw-html" rows="12" placeholder="Paste article markup here..."></textarea>
+        </div>
+
+        <div class="card">
+          <header class="card__header">
+            <h2>Batch controls</h2>
+            <p class="card__subtitle">Start or stop scraping and monitor progress.</p>
+          </header>
+          <div class="control-row">
+            <button id="start-scrape" type="button" class="button button--primary">Start scraping</button>
+            <button id="stop-scrape" type="button" class="button button--secondary" disabled>Stop</button>
+          </div>
+          <div class="progress-block">
+            <progress id="batch-progress" max="1" value="0" aria-describedby="progress-label"></progress>
+            <span id="progress-label" class="progress-label">Idle</span>
+          </div>
+        </div>
+
+        <div class="card">
+          <header class="card__header">
+            <h2>Activity log</h2>
+            <p class="card__subtitle">Real-time updates for the batch runner.</p>
+          </header>
+          <ul id="activity-log" class="activity-log" aria-live="polite"></ul>
+        </div>
+      </section>
+
+      <section class="panel panel--results" aria-label="Results and previews">
+        <div class="card card--tall">
+          <header class="card__header card__header--tabs">
+            <div>
+              <h2>Preview</h2>
+              <p class="card__subtitle">Inspect generated documents, citation tables, and footnotes.</p>
+            </div>
+            <nav class="preview-tabs" role="tablist">
+              <button type="button" class="preview-tab preview-tab--active" data-preview-tab="document" role="tab" aria-selected="true">Documents</button>
+              <button type="button" class="preview-tab" data-preview-tab="citations" role="tab" aria-selected="false">Inline citations</button>
+              <button type="button" class="preview-tab" data-preview-tab="footnotes" role="tab" aria-selected="false">Footnotes</button>
+            </nav>
+          </header>
+          <div class="preview-panes">
+            <section class="preview-pane preview-pane--active" data-pane="document" role="tabpanel" aria-label="Document preview">
+              <div id="document-preview" class="preview-scroll"></div>
+            </section>
+            <section class="preview-pane" data-pane="citations" role="tabpanel" aria-label="Inline citation preview" hidden>
+              <div id="citations-preview" class="preview-scroll"></div>
+            </section>
+            <section class="preview-pane" data-pane="footnotes" role="tabpanel" aria-label="Footnote preview" hidden>
+              <div id="footnotes-preview" class="preview-scroll"></div>
+            </section>
+          </div>
+        </div>
+
+        <div class="card">
+          <header class="card__header">
+            <h2>Export &amp; clipboard</h2>
+            <p class="card__subtitle">Download structured results or copy a quick summary.</p>
+          </header>
+          <div class="export-actions">
+            <button type="button" class="button button--secondary" data-export="json" disabled>Download JSON</button>
+            <button type="button" class="button button--secondary" data-export="markdown" disabled>Download Markdown</button>
+            <button type="button" class="button button--secondary" data-export="html" disabled>Download HTML</button>
+            <button type="button" class="button button--secondary" data-export="bibtex" disabled>Download BibTeX</button>
+          </div>
+          <button id="copy-clipboard" type="button" class="button button--ghost" disabled>Copy Markdown to clipboard</button>
+        </div>
+
+        <div class="card card--validation">
+          <header class="card__header">
+            <h2>Validation &amp; self-check</h2>
+            <p class="card__subtitle">Confirm every numbered inline citation matches a footnote entry.</p>
+          </header>
+          <p id="validation-summary" class="validation-summary">No documents generated yet.</p>
+          <ul id="validation-results" class="validation-list"></ul>
+        </div>
+      </section>
+    </main>
+
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1403 @@
+const DEFAULT_SECTIONS = [
+  { label: 'Abstract', selector: 'section#abstract' },
+  { label: 'Introduction', selector: 'section#introduction' },
+  { label: 'Methods', selector: 'section#methods' },
+  { label: 'Results', selector: 'section#results' },
+  { label: 'Discussion', selector: 'section#discussion' },
+  { label: 'Conclusion', selector: 'section#conclusion' },
+  { label: 'References', selector: 'section[role="doc-endnotes"]' }
+];
+
+const QUICK_LINKS = new Map([
+  [
+    'sample-article',
+    {
+      label: 'Sample journal article',
+      base: 'https://journal.example.org/articles/2024/demo-insights',
+      params: { view: 'full', lang: 'en' },
+      sections: [
+        { label: 'Abstract', selector: 'section#abstract' },
+        { label: 'Introduction', selector: 'section#introduction' },
+        { label: 'Methods', selector: 'section#methods' },
+        { label: 'Results', selector: 'section#results' },
+        { label: 'Discussion', selector: 'section#discussion' },
+        { label: 'References', selector: 'section#references' }
+      ],
+      html: `
+        <article>
+          <header>
+            <h1>Emerging Insights in Community Health</h1>
+          </header>
+          <section id="abstract">
+            <h2>Abstract</h2>
+            <p>
+              Community-driven health programs have demonstrated measurable improvements
+              in wellness indicators across urban centers
+              <sup id="cite-abs-1"><a href="#fn1" role="doc-noteref">1</a></sup>.
+            </p>
+          </section>
+          <section id="introduction">
+            <h2>Introduction</h2>
+            <p>
+              Recent longitudinal studies highlight the importance of neighborhood-based
+              support structures in preventative medicine
+              <sup id="cite-intro-1"><a href="#fn2" role="doc-noteref">2</a></sup>.
+            </p>
+            <p>
+              This paper synthesizes lessons from multi-region pilots while outlining
+              future areas for experimentation
+              <sup id="cite-intro-2"><a href="#fn3" role="doc-noteref" data-tooltip="Pilot program evaluation">3</a></sup>.
+            </p>
+          </section>
+          <section id="methods">
+            <h2>Methods</h2>
+            <p>
+              We combined ethnographic interviews with sensor data analysis across
+              three municipalities
+              <sup id="cite-methods-1"><a href="#fn4" role="doc-noteref">4</a></sup>.
+            </p>
+          </section>
+          <section id="results">
+            <h2>Results</h2>
+            <p>
+              Participation increased by 34% following the introduction of peer-led
+              outreach sessions
+              <sup id="cite-results-1"><a href="#fn5" role="doc-noteref">5</a></sup>.
+            </p>
+          </section>
+          <section id="discussion">
+            <h2>Discussion</h2>
+            <p>
+              The qualitative narratives suggest that co-designed interventions produce
+              durable trust within communities
+              <sup id="cite-discussion-1"><a href="#fn3" role="doc-noteref">3</a></sup>.
+            </p>
+          </section>
+          <section id="references" role="doc-endnotes">
+            <h2>References</h2>
+            <ol class="footnotes">
+              <li id="fn1" role="doc-footnote">
+                1. Gomez, R. <em>Urban Wellness Programs</em>. Journal of Health, 2021.
+              </li>
+              <li id="fn2" role="doc-footnote">
+                2. Chen, A. &amp; Malik, F. "Neighborhood Care". Preventative Care Review, 2020.
+              </li>
+              <li id="fn3" role="doc-footnote">
+                3. Grant, K. Pilot program evaluation memorandum.
+              </li>
+              <li id="fn4" role="doc-footnote">
+                4. Hernandez, P. Sensor-enabled ethnography. Field Methods, 2022.
+              </li>
+              <li id="fn5" role="doc-footnote">
+                5. Ortega, J. Community-led outreach results. Public Health Letters, 2023.
+              </li>
+            </ol>
+          </section>
+        </article>
+      `
+    }
+  ],
+  [
+    'preprint',
+    {
+      label: 'Preprint landing page',
+      base: 'https://preprints.example.net/manuscript/ai-literature-review',
+      params: { download: 'pdf', format: 'html' },
+      sections: [
+        { label: 'Summary', selector: 'section#summary' },
+        { label: 'Background', selector: 'section#background' },
+        { label: 'Findings', selector: 'section#findings' },
+        { label: 'References', selector: 'section#endnotes' }
+      ],
+      html: `
+        <article>
+          <section id="summary">
+            <h2>Summary</h2>
+            <p>
+              We provide an overview of emerging evaluation datasets for large language models
+              <sup><a role="doc-noteref" href="#note1">1</a></sup> while examining model behavior in
+              zero-shot conditions.
+            </p>
+          </section>
+          <section id="background">
+            <h2>Background</h2>
+            <p>
+              Contemporary approaches rely on synthetic benchmarks that do not always correlate
+              with human preference studies <sup data-citation-id="c-bg-2" data-footnote-id="note2">2</sup>.
+            </p>
+          </section>
+          <section id="findings">
+            <h2>Findings</h2>
+            <ul>
+              <li>
+                Pairwise human evaluation remains the most reliable indicator of deployment readiness
+                <sup><a href="#note3" role="doc-noteref">3</a></sup>.
+              </li>
+              <li>
+                Annotation costs can be reduced with expert-in-the-loop tooling
+                <sup title="Workshop best practices" href="#note4">4</sup>.
+              </li>
+            </ul>
+          </section>
+          <section id="endnotes" role="doc-endnotes">
+            <h2>Endnotes</h2>
+            <div class="footnote-wrapper">
+              <p id="note1" role="doc-footnote">1. Venkatesh, R. et al. Benchmarking LLMs. 2023.</p>
+              <p id="note2" role="doc-footnote">2. Solis, P. Synthetic vs. human alignment. 2022.</p>
+              <p id="note3" role="doc-footnote">3. Huang, M. et al. Human feedback loops. 2021.</p>
+              <p id="note4" role="doc-footnote">4. Martinez, L. Expert annotation workshops. 2020.</p>
+            </div>
+          </section>
+        </article>
+      `
+    }
+  ],
+  [
+    'policy',
+    {
+      label: 'Policy brief',
+      base: 'https://policy.example.gov/briefs/transportation-reform',
+      params: { view: 'print' },
+      sections: [
+        { label: 'Executive Summary', selector: 'section#executive-summary' },
+        { label: 'Key Recommendations', selector: 'section#recommendations' },
+        { label: 'Appendix', selector: 'section#appendix' }
+      ],
+      html: `
+        <article>
+          <section id="executive-summary">
+            <h2>Executive Summary</h2>
+            <p>
+              Transit ridership increased in cities that adopted congestion pricing models
+              <sup data-citation-id="es-1"><a href="#ref-a">1</a></sup> while emissions decreased in
+              low-income corridors <sup data-citation-id="es-2" data-footnote-id="ref-b">2</sup>.
+            </p>
+          </section>
+          <section id="recommendations">
+            <h2>Key Recommendations</h2>
+            <ol>
+              <li>
+                Establish adaptive tolling schedules to balance throughput
+                <sup aria-label="Funding analysis" href="#ref-c">3</sup>.
+              </li>
+              <li>
+                Reinvest toll revenue into equitable mobility programs (see Appendix)
+                <sup><a href="#ref-d">4</a></sup>.
+              </li>
+            </ol>
+          </section>
+          <section id="appendix">
+            <h2>Appendix</h2>
+            <p>
+              Supplemental research materials are available upon request.
+            </p>
+          </section>
+          <aside class="footnotes">
+            <h2>References</h2>
+            <ul>
+              <li id="ref-a">1. City Mobility Lab. Congestion Pricing Evaluation. 2022.</li>
+              <li id="ref-b">2. Rivera, T. Emissions after pricing. Climate Works, 2021.</li>
+              <li id="ref-c">3. Lopez, J. Funding transportation transitions. Policy Forum, 2020.</li>
+              <li id="ref-d">4. National Transit Council. Mobility Equity Fund. 2023.</li>
+              <li id="ref-e">5. Advisory Committee on Urban Traffic. Interim Memo.</li>
+            </ul>
+          </aside>
+        </article>
+      `
+    }
+  ]
+]);
+
+document.addEventListener('DOMContentLoaded', () => {
+  const state = {
+    results: [],
+    isScraping: false,
+    stopRequested: false,
+    selectedModes: new Set(['inline-footnotes']),
+    composedUrl: '',
+    activeTab: 'document'
+  };
+
+  const baseUrlInput = document.querySelector('#base-url');
+  const queryParamsContainer = document.querySelector('#query-params');
+  const addParamButton = document.querySelector('#add-param');
+  const composedUrlLink = document.querySelector('#composed-url');
+  const quickLinkButtons = document.querySelectorAll('[data-quick-link]');
+  const modeButtons = document.querySelectorAll('.mode-toggle .toggle-button');
+  const sectionList = document.querySelector('#section-list');
+  const customSectionInput = document.querySelector('#custom-section');
+  const addSectionButton = document.querySelector('#add-section');
+  const rawHtmlInput = document.querySelector('#raw-html');
+  const startButton = document.querySelector('#start-scrape');
+  const stopButton = document.querySelector('#stop-scrape');
+  const progressBar = document.querySelector('#batch-progress');
+  const progressLabel = document.querySelector('#progress-label');
+  const activityLog = document.querySelector('#activity-log');
+  const previewTabs = document.querySelectorAll('.preview-tab');
+  const previewPanes = document.querySelectorAll('.preview-pane');
+  const documentPreview = document.querySelector('#document-preview');
+  const citationsPreview = document.querySelector('#citations-preview');
+  const footnotesPreview = document.querySelector('#footnotes-preview');
+  const exportButtons = document.querySelectorAll('[data-export]');
+  const copyButton = document.querySelector('#copy-clipboard');
+  const validationSummary = document.querySelector('#validation-summary');
+  const validationList = document.querySelector('#validation-results');
+
+  init();
+
+  function init() {
+    renderSections(DEFAULT_SECTIONS);
+    resetParams();
+    updateComposedUrl();
+    setActivePreviewTab('document');
+    renderEmptyPreviews();
+    updateValidation();
+    updateExportAvailability();
+    progressLabel.textContent = 'Idle';
+    attachEventListeners();
+    logMessage('Ready. Load a preset or paste markup to begin.');
+    applyQuickLink('sample-article');
+  }
+
+  function attachEventListeners() {
+    baseUrlInput.addEventListener('input', updateComposedUrl);
+    addParamButton.addEventListener('click', () => addQueryParamRow());
+
+    quickLinkButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const key = button.dataset.quickLink;
+        applyQuickLink(key);
+      });
+    });
+
+    modeButtons.forEach((button) => {
+      button.addEventListener('click', () => toggleMode(button));
+    });
+
+    addSectionButton.addEventListener('click', handleCustomSectionSubmit);
+    customSectionInput.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleCustomSectionSubmit();
+      }
+    });
+
+    startButton.addEventListener('click', startScraping);
+    stopButton.addEventListener('click', stopScraping);
+
+    previewTabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        setActivePreviewTab(tab.dataset.previewTab);
+      });
+    });
+
+    exportButtons.forEach((button) => {
+      button.addEventListener('click', () => handleExport(button.dataset.export));
+    });
+
+    copyButton.addEventListener('click', copyMarkdownToClipboard);
+  }
+
+  function renderSections(sections) {
+    sectionList.innerHTML = '';
+    sections.forEach((section) => {
+      createSectionOption(section.label, section.selector, true);
+    });
+  }
+
+  function createSectionOption(label, selector = '', checked = false) {
+    if (!label) {
+      return;
+    }
+    const normalizedLabel = label.trim();
+    const existing = Array.from(sectionList.querySelectorAll('input[name="sections"]')).find(
+      (input) => input.dataset.label === normalizedLabel.toLowerCase() && (input.dataset.selector || '') === (selector || '')
+    );
+    if (existing) {
+      existing.checked = checked;
+      return existing;
+    }
+
+    const wrapper = document.createElement('label');
+    wrapper.className = 'checkbox';
+
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.name = 'sections';
+    input.value = normalizedLabel;
+    input.dataset.label = normalizedLabel.toLowerCase();
+    if (selector) {
+      input.dataset.selector = selector;
+    }
+    input.checked = checked;
+
+    const textContainer = document.createElement('div');
+    textContainer.className = 'option-text';
+    const title = document.createElement('span');
+    title.textContent = normalizedLabel;
+    textContainer.appendChild(title);
+    if (selector) {
+      const detail = document.createElement('small');
+      detail.textContent = selector;
+      textContainer.appendChild(detail);
+    }
+
+    wrapper.append(input, textContainer);
+    sectionList.appendChild(wrapper);
+    return input;
+  }
+
+  function handleCustomSectionSubmit() {
+    const rawValue = (customSectionInput.value || '').trim();
+    if (!rawValue) {
+      return;
+    }
+    const { label, selector } = parseSectionInput(rawValue);
+    const added = createSectionOption(label, selector, true);
+    if (added) {
+      logMessage(`Added section “${label}”${selector ? ` with selector ${selector}` : ''}.`, 'success');
+    }
+    customSectionInput.value = '';
+    customSectionInput.focus();
+  }
+
+  function parseSectionInput(value) {
+    const [labelPart, selectorPart] = value.split('::');
+    const label = (labelPart || value).trim();
+    const selector = selectorPart ? selectorPart.trim() : '';
+    return { label, selector };
+  }
+
+  function resetParams(params = {}) {
+    queryParamsContainer.innerHTML = '';
+    const entries = Object.entries(params);
+    if (!entries.length) {
+      addQueryParamRow();
+      return;
+    }
+    entries.forEach(([key, value]) => addQueryParamRow(key, value));
+  }
+
+  function addQueryParamRow(key = '', value = '') {
+    const row = document.createElement('div');
+    row.className = 'param-row';
+
+    const keyInput = document.createElement('input');
+    keyInput.type = 'text';
+    keyInput.placeholder = 'parameter';
+    keyInput.className = 'param-key';
+    keyInput.value = key;
+
+    const delimiter = document.createElement('span');
+    delimiter.className = 'delimiter';
+    delimiter.textContent = '=';
+
+    const valueInput = document.createElement('input');
+    valueInput.type = 'text';
+    valueInput.placeholder = 'value';
+    valueInput.className = 'param-value';
+    valueInput.value = value;
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'button button--ghost param-remove';
+    removeButton.setAttribute('aria-label', 'Remove parameter');
+    removeButton.textContent = '×';
+
+    removeButton.addEventListener('click', () => {
+      row.remove();
+      updateComposedUrl();
+    });
+
+    keyInput.addEventListener('input', updateComposedUrl);
+    valueInput.addEventListener('input', updateComposedUrl);
+
+    row.append(keyInput, delimiter, valueInput, removeButton);
+    queryParamsContainer.appendChild(row);
+  }
+
+  function collectQueryParams() {
+    const entries = [];
+    queryParamsContainer.querySelectorAll('.param-row').forEach((row) => {
+      const key = row.querySelector('.param-key').value.trim();
+      const value = row.querySelector('.param-value').value.trim();
+      if (key) {
+        entries.push([key, value]);
+      }
+    });
+    return entries;
+  }
+
+  function composeUrl(base, params) {
+    if (!base) {
+      return '';
+    }
+    const search = new URLSearchParams();
+    params.forEach(([key, value]) => {
+      search.append(key, value);
+    });
+    const queryString = search.toString();
+    if (!queryString) {
+      return base;
+    }
+    const joiner = base.includes('?') ? '&' : '?';
+    return `${base}${joiner}${queryString}`;
+  }
+
+  function updateComposedUrl() {
+    const base = (baseUrlInput.value || '').trim();
+    const params = collectQueryParams();
+    const composed = composeUrl(base, params);
+    composedUrlLink.textContent = composed || '—';
+    composedUrlLink.href = composed || '#';
+    state.composedUrl = composed;
+  }
+
+  function toggleMode(button) {
+    const mode = button.dataset.mode;
+    const isActive = button.classList.contains('toggle-button--active');
+    if (isActive && state.selectedModes.size === 1) {
+      logMessage('At least one scraping mode must remain active.', 'warning');
+      return;
+    }
+    const willActivate = !isActive;
+    button.classList.toggle('toggle-button--active', willActivate);
+    button.setAttribute('aria-pressed', String(willActivate));
+    if (willActivate) {
+      state.selectedModes.add(mode);
+    } else {
+      state.selectedModes.delete(mode);
+    }
+    updatePreviews();
+  }
+
+  function applyQuickLink(key) {
+    const preset = QUICK_LINKS.get(key);
+    if (!preset) {
+      logMessage(`Preset "${key}" is not available.`, 'error');
+      return;
+    }
+    baseUrlInput.value = preset.base || '';
+    resetParams(preset.params || {});
+    renderSections(preset.sections || DEFAULT_SECTIONS);
+    if (preset.html) {
+      rawHtmlInput.value = preset.html.trim();
+    }
+    updateComposedUrl();
+    logMessage(`Loaded preset: ${preset.label}.`, 'success');
+  }
+
+  function getSelectedSections() {
+    return Array.from(sectionList.querySelectorAll('input[name="sections"]:checked')).map((input, index) => ({
+      label: input.value,
+      selector: input.dataset.selector || '',
+      index
+    }));
+  }
+
+  function setActivePreviewTab(tabName) {
+    state.activeTab = tabName;
+    previewTabs.forEach((tab) => {
+      const isActive = tab.dataset.previewTab === tabName;
+      tab.classList.toggle('preview-tab--active', isActive);
+      tab.setAttribute('aria-selected', String(isActive));
+    });
+    previewPanes.forEach((pane) => {
+      const isActive = pane.dataset.pane === tabName;
+      pane.classList.toggle('preview-pane--active', isActive);
+      pane.hidden = !isActive;
+    });
+  }
+
+  function renderEmptyPreviews() {
+    const placeholder = '<div class="empty-state">Run a scrape to view generated documents.</div>';
+    documentPreview.innerHTML = placeholder;
+    citationsPreview.innerHTML = placeholder;
+    footnotesPreview.innerHTML = placeholder;
+  }
+
+  function startScraping() {
+    if (state.isScraping) {
+      return;
+    }
+    const sections = getSelectedSections();
+    if (!sections.length) {
+      logMessage('Select at least one section before starting.', 'error');
+      return;
+    }
+
+    const sourceHtml = (rawHtmlInput.value || '').trim();
+    if (!sourceHtml) {
+      logMessage('Source markup is empty. Parsing will likely return warnings.', 'warning');
+    }
+
+    const parser = new DOMParser();
+    const parsedDocument = parser.parseFromString(sourceHtml || '<article></article>', 'text/html');
+    if (parsedDocument.querySelector('parsererror')) {
+      logMessage('Unable to parse the provided HTML snippet.', 'error');
+      return;
+    }
+
+    state.results = [];
+    state.stopRequested = false;
+    state.isScraping = true;
+    startButton.disabled = true;
+    stopButton.disabled = false;
+    progressBar.max = Math.max(sections.length, 1);
+    progressBar.value = 0;
+    progressLabel.textContent = `Queued ${sections.length} section${sections.length === 1 ? '' : 's'}.`;
+    renderEmptyPreviews();
+    updateValidation();
+    updateExportAvailability();
+    logMessage('Starting scrape run…');
+
+    runScrape(parsedDocument, sections).catch((error) => {
+      console.error(error);
+      logMessage(`Unexpected error: ${error.message}`, 'error');
+    });
+  }
+
+  async function runScrape(doc, sections) {
+    for (let index = 0; index < sections.length; index += 1) {
+      if (state.stopRequested) {
+        logMessage('Stop requested. Finishing current section before exiting.', 'warning');
+        break;
+      }
+      const section = sections[index];
+      progressLabel.textContent = `Processing ${section.label} (${index + 1}/${sections.length})`;
+      logMessage(`Processing ${section.label}…`);
+      try {
+        const result = await processSection(doc, section, index, sections.length);
+        state.results.push(result);
+        logMessage(`Completed ${section.label}.`, 'success');
+      } catch (error) {
+        console.error(error);
+        logMessage(`Failed to process ${section.label}: ${error.message}`, 'error');
+      }
+      progressBar.value = index + 1;
+      updatePreviews();
+      updateValidation();
+      updateExportAvailability();
+      await simulateProcessingDelay(180);
+    }
+
+    state.isScraping = false;
+    startButton.disabled = false;
+    stopButton.disabled = true;
+
+    if (state.stopRequested) {
+      logMessage('Scrape run stopped by user.', 'warning');
+      progressLabel.textContent = 'Stopped by user.';
+    } else {
+      logMessage('Scrape run complete.', 'success');
+      progressLabel.textContent = `Completed ${state.results.length}/${sections.length} section${sections.length === 1 ? '' : 's'}.`;
+    }
+
+    state.stopRequested = false;
+  }
+
+  function stopScraping() {
+    if (!state.isScraping) {
+      return;
+    }
+    state.stopRequested = true;
+    stopButton.disabled = true;
+    logMessage('Stop requested. Awaiting current section to finish…', 'warning');
+    progressLabel.textContent = 'Stop requested…';
+  }
+
+  async function processSection(doc, section, index) {
+    await simulateProcessingDelay(220 + Math.random() * 160);
+    const extraction = extractSection(doc, section);
+    const citations = extractCitations(extraction.fragment, doc);
+    return {
+      sectionLabel: section.label,
+      selector: section.selector,
+      index,
+      url: state.composedUrl,
+      html: extraction.html,
+      markdown: extraction.markdown,
+      text: extraction.text,
+      modes: Array.from(state.selectedModes),
+      warnings: extraction.warnings,
+      citations
+    };
+  }
+
+  function extractSection(doc, section) {
+    const warnings = [];
+    let fragment = document.createElement('div');
+
+    if (section.selector) {
+      const node = doc.querySelector(section.selector);
+      if (node) {
+        fragment.appendChild(node.cloneNode(true));
+      } else {
+        warnings.push(`Selector "${section.selector}" not found.`);
+      }
+    }
+
+    if (!section.selector || fragment.childNodes.length === 0) {
+      const heading = locateHeading(doc, section.label) || fallbackSectionNode(doc, section.label);
+      if (heading) {
+        fragment = buildFragmentFromHeading(heading);
+      } else if (!section.selector) {
+        warnings.push(`Heading for "${section.label}" not found.`);
+      }
+    }
+
+    const html = fragment.innerHTML.trim();
+    const text = fragment.textContent.replace(/\s+/g, ' ').trim();
+    const markdown = html ? fragmentToMarkdown(fragment) : '';
+    if (!html) {
+      warnings.push('No content captured for this section.');
+    }
+    return { fragment, html, text, markdown, warnings };
+  }
+
+  function locateHeading(doc, label) {
+    const headings = Array.from(doc.querySelectorAll('h1, h2, h3, h4, h5, h6'));
+    const normalizedTarget = normalizeText(label);
+    let fallback = null;
+    for (const heading of headings) {
+      const normalizedHeading = normalizeText(heading.textContent);
+      if (normalizedHeading === normalizedTarget) {
+        return heading;
+      }
+      if (!fallback && normalizedHeading.includes(normalizedTarget)) {
+        fallback = heading;
+      }
+    }
+    return fallback;
+  }
+
+  function fallbackSectionNode(doc, label) {
+    const slug = slugify(label);
+    return doc.getElementById(slug) || doc.querySelector(`[data-section="${slug}"]`);
+  }
+
+  function buildFragmentFromHeading(heading) {
+    const container = document.createElement('div');
+    const level = parseInt(heading.tagName.replace('H', ''), 10);
+    container.appendChild(heading.cloneNode(true));
+    let sibling = heading.nextElementSibling;
+    while (sibling) {
+      if (/^H[1-6]$/.test(sibling.tagName)) {
+        const siblingLevel = parseInt(sibling.tagName.replace('H', ''), 10);
+        if (siblingLevel <= level) {
+          break;
+        }
+      }
+      container.appendChild(sibling.cloneNode(true));
+      sibling = sibling.nextElementSibling;
+    }
+    return container;
+  }
+
+  function fragmentToMarkdown(fragment) {
+    const lines = [];
+    fragment.childNodes.forEach((node) => convertNodeToMarkdown(node, lines, 0));
+    return lines.join('\n\n').replace(/\n{3,}/g, '\n\n').trim();
+  }
+
+  function convertNodeToMarkdown(node, lines, depth) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent.replace(/\s+/g, ' ').trim();
+      if (text) {
+        lines.push(text);
+      }
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
+    const tag = node.tagName.toUpperCase();
+    const text = node.textContent.replace(/\s+/g, ' ').trim();
+    switch (tag) {
+      case 'H1':
+        lines.push(`# ${text}`);
+        break;
+      case 'H2':
+        lines.push(`## ${text}`);
+        break;
+      case 'H3':
+        lines.push(`### ${text}`);
+        break;
+      case 'H4':
+        lines.push(`#### ${text}`);
+        break;
+      case 'P':
+        lines.push(text);
+        break;
+      case 'BLOCKQUOTE': {
+        const quoteLines = text.split(/\n+/).map((part) => `> ${part.trim()}`).join('\n');
+        lines.push(quoteLines);
+        break;
+      }
+      case 'UL': {
+        Array.from(node.children).forEach((child) => {
+          if (child.tagName && child.tagName.toUpperCase() === 'LI') {
+            const childLines = [];
+            child.childNodes.forEach((grandChild) => convertNodeToMarkdown(grandChild, childLines, depth + 1));
+            const content = childLines.join(' ').trim();
+            lines.push(`${'  '.repeat(depth)}- ${content}`);
+          }
+        });
+        break;
+      }
+      case 'OL': {
+        Array.from(node.children).forEach((child, index) => {
+          if (child.tagName && child.tagName.toUpperCase() === 'LI') {
+            const childLines = [];
+            child.childNodes.forEach((grandChild) => convertNodeToMarkdown(grandChild, childLines, depth + 1));
+            const content = childLines.join(' ').trim();
+            lines.push(`${'  '.repeat(depth)}${index + 1}. ${content}`);
+          }
+        });
+        break;
+      }
+      case 'TABLE':
+        lines.push(text);
+        break;
+      default:
+        Array.from(node.childNodes).forEach((child) => convertNodeToMarkdown(child, lines, depth));
+    }
+  }
+
+  function extractCitations(fragment, doc) {
+    const inline = [];
+    const inlineSelectors = ['sup', 'a[role="doc-noteref"]', 'a[href^="#fn"]', 'span[data-citation-id]', 'span.citation'];
+    const inlineNodes = fragment
+      ? Array.from(new Set(Array.from(fragment.querySelectorAll(inlineSelectors.join(',')))))
+      : [];
+    const inlineFootnoteIds = new Set();
+
+    inlineNodes.forEach((node) => {
+      const citation = parseInlineCitation(node, doc);
+      if (!citation) {
+        return;
+      }
+      inline.push(citation);
+      if (citation.footnoteId) {
+        inlineFootnoteIds.add(citation.footnoteId);
+      }
+    });
+
+    const footnotes = collectFootnotes(doc);
+    const missingFootnotes = inline.filter((item) => item.footnoteId && !footnotes.find((fn) => fn.id === item.footnoteId));
+    const unreferencedFootnotes = footnotes.filter((item) => item.id && !inlineFootnoteIds.has(item.id));
+    const inlineWithoutNumbers = inline.filter((item) => !item.number);
+    const footnotesWithoutNumbers = footnotes.filter((item) => !item.number);
+
+    return {
+      inline,
+      footnotes,
+      missingFootnotes,
+      unreferencedFootnotes,
+      inlineWithoutNumbers,
+      footnotesWithoutNumbers
+    };
+  }
+
+  function parseInlineCitation(node, doc) {
+    const citation = {
+      id: node.id || node.getAttribute('data-citation-id') || node.getAttribute('name') || '',
+      number: null,
+      footnoteId: null,
+      text: node.textContent.replace(/\s+/g, ' ').trim(),
+      html: node.outerHTML.trim(),
+      tooltip: ''
+    };
+
+    let href = '';
+    if (node.tagName && node.tagName.toUpperCase() === 'A') {
+      href = node.getAttribute('href') || '';
+    } else {
+      const anchor = node.querySelector('a[href]');
+      if (anchor) {
+        href = anchor.getAttribute('href') || '';
+        if (!citation.id) {
+          citation.id = anchor.id || anchor.getAttribute('name') || '';
+        }
+      }
+    }
+
+    if (!href) {
+      const fallbackHref = node.getAttribute('href');
+      if (fallbackHref) {
+        href = fallbackHref;
+      }
+    }
+
+    if (href && href.startsWith('#')) {
+      citation.footnoteId = href.slice(1);
+    } else if (node.dataset && node.dataset.footnoteId) {
+      citation.footnoteId = node.dataset.footnoteId;
+    }
+
+    const numberMatch = citation.text.match(/\d+/);
+    citation.number = numberMatch ? numberMatch[0] : null;
+
+    citation.tooltip =
+      node.getAttribute('data-tooltip') ||
+      node.getAttribute('title') ||
+      node.getAttribute('aria-label') ||
+      '';
+
+    if (!citation.tooltip && citation.footnoteId) {
+      const footnote = doc.getElementById(citation.footnoteId);
+      if (footnote) {
+        citation.tooltip = footnote.textContent.replace(/\s+/g, ' ').trim();
+      }
+    }
+
+    return citation;
+  }
+
+  function collectFootnotes(doc) {
+    const selectors = [
+      '[role="doc-footnote"]',
+      'section[role="doc-endnotes"] li',
+      'ol.footnotes li',
+      'div.footnote',
+      'li[id^="fn"]',
+      'p[id^="fn"]',
+      'li[id^="ref"]',
+      'li[id^="note"]'
+    ];
+    const seen = new Set();
+    const results = [];
+
+    selectors.forEach((selector) => {
+      doc.querySelectorAll(selector).forEach((node) => {
+        let id = node.id || node.getAttribute('data-footnote-id') || '';
+        let generated = false;
+        if (!id) {
+          generated = true;
+          id = `footnote-${results.length + 1}`;
+          while (seen.has(id)) {
+            id = `footnote-${results.length + 1}-${Math.floor(Math.random() * 1000)}`;
+          }
+        }
+        if (seen.has(id)) {
+          return;
+        }
+        seen.add(id);
+        const text = node.textContent.replace(/\s+/g, ' ').trim();
+        const numberMatch = text.match(/^(\[)?(\d+)[\]\.:\s]/);
+        const number = numberMatch ? numberMatch[2] : null;
+        results.push({
+          id,
+          number,
+          text,
+          html: node.innerHTML.trim(),
+          generated
+        });
+      });
+    });
+
+    results.sort((a, b) => {
+      if (a.number && b.number) {
+        return Number(a.number) - Number(b.number);
+      }
+      return a.id.localeCompare(b.id);
+    });
+
+    return results;
+  }
+
+  function updatePreviews() {
+    if (!state.results.length) {
+      renderEmptyPreviews();
+      return;
+    }
+
+    renderDocumentPreview();
+    renderCitationsPreview();
+    renderFootnotesPreview();
+  }
+
+  function renderDocumentPreview() {
+    documentPreview.innerHTML = '';
+    state.results.forEach((result) => {
+      const block = document.createElement('article');
+      block.className = 'result-block';
+
+      const header = document.createElement('div');
+      header.className = 'result-block__header';
+      const title = document.createElement('h3');
+      title.textContent = result.sectionLabel;
+      header.appendChild(title);
+
+      const meta = document.createElement('div');
+      meta.className = 'result-block__meta';
+      meta.appendChild(createPill(`${result.citations.inline.length} inline`));
+      meta.appendChild(createPill(`${result.citations.footnotes.length} footnotes`));
+      result.modes.forEach((mode) => {
+        const modePill = createPill(mode.replace(/-/g, ' '));
+        modePill.classList.add('pill--mode');
+        meta.appendChild(modePill);
+      });
+      header.appendChild(meta);
+      block.appendChild(header);
+
+      if (result.selector) {
+        const selectorNote = document.createElement('div');
+        selectorNote.className = 'muted';
+        selectorNote.textContent = `Selector: ${result.selector}`;
+        block.appendChild(selectorNote);
+      }
+
+      if (result.warnings.length) {
+        const warningsList = document.createElement('ul');
+        warningsList.className = 'result-block__warnings';
+        result.warnings.forEach((warning) => {
+          const item = document.createElement('li');
+          item.textContent = warning;
+          warningsList.appendChild(item);
+        });
+        block.appendChild(warningsList);
+      }
+
+      const htmlContainer = document.createElement('div');
+      htmlContainer.className = 'result-block__html';
+      if (result.html) {
+        htmlContainer.innerHTML = result.html;
+      } else {
+        htmlContainer.innerHTML = '<p class="muted">No markup captured for this section.</p>';
+      }
+      block.appendChild(htmlContainer);
+
+      const markdownDetails = document.createElement('details');
+      markdownDetails.innerHTML = `<summary>Show Markdown</summary><pre>${escapeHtml(result.markdown || '_No Markdown available_')}</pre>`;
+      block.appendChild(markdownDetails);
+
+      const textDetails = document.createElement('details');
+      textDetails.innerHTML = `<summary>Show plain text</summary><pre>${escapeHtml(result.text || '')}</pre>`;
+      block.appendChild(textDetails);
+
+      documentPreview.appendChild(block);
+    });
+  }
+
+  function renderCitationsPreview() {
+    citationsPreview.innerHTML = '';
+    state.results.forEach((result) => {
+      const block = document.createElement('article');
+      block.className = 'result-block';
+      const header = document.createElement('div');
+      header.className = 'result-block__header';
+      const title = document.createElement('h3');
+      title.textContent = result.sectionLabel;
+      header.appendChild(title);
+      block.appendChild(header);
+
+      if (!result.citations.inline.length) {
+        const empty = document.createElement('p');
+        empty.className = 'muted';
+        empty.textContent = 'No inline citations detected.';
+        block.appendChild(empty);
+      } else {
+        const table = document.createElement('table');
+        table.className = 'preview-table';
+        table.innerHTML = '<thead><tr><th>#</th><th>Inline reference</th><th>Footnote</th></tr></thead>';
+        const tbody = document.createElement('tbody');
+        result.citations.inline.forEach((citation) => {
+          const row = document.createElement('tr');
+          const numberCell = document.createElement('td');
+          numberCell.textContent = citation.number || '—';
+          const textCell = document.createElement('td');
+          textCell.textContent = citation.text || citation.html;
+          const footnoteCell = document.createElement('td');
+          footnoteCell.textContent = citation.footnoteId ? `#${citation.footnoteId}` : 'Unlinked';
+          if (citation.tooltip) {
+            const detail = document.createElement('small');
+            detail.textContent = citation.tooltip;
+            footnoteCell.appendChild(detail);
+          }
+          row.append(numberCell, textCell, footnoteCell);
+          tbody.appendChild(row);
+        });
+        table.appendChild(tbody);
+        block.appendChild(table);
+      }
+
+      citationsPreview.appendChild(block);
+    });
+  }
+
+  function renderFootnotesPreview() {
+    footnotesPreview.innerHTML = '';
+    state.results.forEach((result) => {
+      const block = document.createElement('article');
+      block.className = 'result-block';
+      const header = document.createElement('div');
+      header.className = 'result-block__header';
+      const title = document.createElement('h3');
+      title.textContent = result.sectionLabel;
+      header.appendChild(title);
+      block.appendChild(header);
+
+      if (!result.citations.footnotes.length) {
+        const empty = document.createElement('p');
+        empty.className = 'muted';
+        empty.textContent = 'No footnotes captured for this section.';
+        block.appendChild(empty);
+      } else {
+        const list = document.createElement('ol');
+        result.citations.footnotes.forEach((footnote) => {
+          const item = document.createElement('li');
+          item.innerHTML = `<strong>${escapeHtml(footnote.number || footnote.id)}</strong> ${escapeHtml(footnote.text)}`;
+          if (footnote.generated) {
+            const generated = document.createElement('small');
+            generated.className = 'muted';
+            generated.textContent = ' (generated identifier)';
+            item.appendChild(generated);
+          }
+          list.appendChild(item);
+        });
+        block.appendChild(list);
+      }
+
+      footnotesPreview.appendChild(block);
+    });
+  }
+
+  function updateValidation() {
+    validationList.innerHTML = '';
+    if (!state.results.length) {
+      validationSummary.textContent = 'No documents generated yet.';
+      return;
+    }
+
+    let totalIssues = 0;
+
+    state.results.forEach((result) => {
+      const entry = document.createElement('li');
+      entry.className = 'validation-entry';
+      const title = document.createElement('h4');
+      title.textContent = result.sectionLabel;
+      entry.appendChild(title);
+
+      const issues = [];
+      const { missingFootnotes, unreferencedFootnotes, inlineWithoutNumbers, footnotesWithoutNumbers } = result.citations;
+
+      if (missingFootnotes.length) {
+        totalIssues += missingFootnotes.length;
+        issues.push(`${missingFootnotes.length} inline reference${missingFootnotes.length === 1 ? '' : 's'} missing footnotes (${missingFootnotes
+          .map((item) => item.number || item.footnoteId || '?')
+          .join(', ')})`);
+      }
+      if (unreferencedFootnotes.length) {
+        totalIssues += unreferencedFootnotes.length;
+        issues.push(`${unreferencedFootnotes.length} footnote${unreferencedFootnotes.length === 1 ? '' : 's'} without inline references (${unreferencedFootnotes
+          .map((item) => item.number || item.id)
+          .join(', ')})`);
+      }
+      if (inlineWithoutNumbers.length) {
+        totalIssues += inlineWithoutNumbers.length;
+        issues.push(`${inlineWithoutNumbers.length} inline citation${inlineWithoutNumbers.length === 1 ? '' : 's'} missing numbers.`);
+      }
+      if (footnotesWithoutNumbers.length) {
+        totalIssues += footnotesWithoutNumbers.length;
+        issues.push(`${footnotesWithoutNumbers.length} footnote${footnotesWithoutNumbers.length === 1 ? '' : 's'} missing numbers.`);
+      }
+      if (result.warnings.length) {
+        issues.push(...result.warnings);
+      }
+
+      if (!issues.length) {
+        entry.classList.add('validation-entry--ok');
+        entry.appendChild(document.createTextNode('All inline references map to footnotes.'));
+      } else {
+        entry.classList.add('validation-entry--warning');
+        const list = document.createElement('ul');
+        issues.forEach((issue) => {
+          const item = document.createElement('li');
+          item.textContent = issue;
+          list.appendChild(item);
+        });
+        entry.appendChild(list);
+      }
+
+      validationList.appendChild(entry);
+    });
+
+    if (totalIssues === 0) {
+      validationSummary.textContent = '✅ All inline citations are paired with matching footnotes.';
+    } else {
+      validationSummary.textContent = `⚠️ Detected ${totalIssues} validation issue${totalIssues === 1 ? '' : 's'} across ${state.results.length} section${state.results.length === 1 ? '' : 's'}.`;
+    }
+  }
+
+  function updateExportAvailability() {
+    const hasResults = state.results.length > 0;
+    exportButtons.forEach((button) => {
+      button.disabled = !hasResults;
+    });
+    copyButton.disabled = !hasResults;
+  }
+
+  function handleExport(type) {
+    if (!state.results.length) {
+      logMessage('Generate at least one document before exporting.', 'warning');
+      return;
+    }
+    const payload = getExportPayload();
+    let content = '';
+    let mime = 'text/plain';
+    let filename = `scraper-export-${Date.now()}`;
+
+    switch (type) {
+      case 'json':
+        content = JSON.stringify(payload, null, 2);
+        mime = 'application/json';
+        filename += '.json';
+        break;
+      case 'markdown':
+        content = buildMarkdownDocument(payload);
+        mime = 'text/markdown';
+        filename += '.md';
+        break;
+      case 'html':
+        content = buildHtmlDocument(payload);
+        mime = 'text/html';
+        filename += '.html';
+        break;
+      case 'bibtex':
+        content = buildBibtexDocument(payload);
+        mime = 'application/x-bibtex';
+        filename += '.bib';
+        break;
+      default:
+        logMessage(`Unknown export type: ${type}`, 'error');
+        return;
+    }
+
+    downloadFile(filename, content, mime);
+    logMessage(`Exported ${type.toUpperCase()} file.`, 'success');
+  }
+
+  async function copyMarkdownToClipboard() {
+    if (!state.results.length) {
+      logMessage('Nothing to copy yet. Run a scrape first.', 'warning');
+      return;
+    }
+    const payload = getExportPayload();
+    const markdown = buildMarkdownDocument(payload);
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(markdown);
+        logMessage('Markdown copied to clipboard.', 'success');
+        return;
+      } catch (error) {
+        console.warn('Clipboard API failed, falling back to execCommand.', error);
+      }
+    }
+
+    const tempArea = document.createElement('textarea');
+    tempArea.value = markdown;
+    tempArea.setAttribute('readonly', 'readonly');
+    tempArea.style.position = 'absolute';
+    tempArea.style.left = '-9999px';
+    document.body.appendChild(tempArea);
+    tempArea.select();
+    const copied = document.execCommand('copy');
+    document.body.removeChild(tempArea);
+    if (copied) {
+      logMessage('Markdown copied to clipboard.', 'success');
+    } else {
+      logMessage('Clipboard copy is not supported in this browser.', 'error');
+    }
+  }
+
+  function getExportPayload() {
+    return {
+      generatedAt: new Date().toISOString(),
+      sourceUrl: state.composedUrl,
+      modes: Array.from(state.selectedModes),
+      results: state.results
+    };
+  }
+
+  function buildMarkdownDocument(payload) {
+    const lines = ['# Citation Scraper Export'];
+    if (payload.sourceUrl) {
+      lines.push('', `Source: ${payload.sourceUrl}`);
+    }
+    if (payload.modes.length) {
+      lines.push('', `Modes: ${payload.modes.join(', ')}`);
+    }
+    payload.results.forEach((result) => {
+      lines.push('', `## ${result.sectionLabel}`);
+      lines.push('', result.markdown || '_No content captured._');
+      if (result.citations.inline.length) {
+        lines.push('', '**Inline citations**');
+        result.citations.inline.forEach((citation) => {
+          const target = citation.footnoteId ? `#${citation.footnoteId}` : 'unlinked';
+          const detail = citation.tooltip ? ` — ${citation.tooltip}` : '';
+          lines.push(`- ${citation.number || '—'} → ${target}${detail}`);
+        });
+      }
+      if (result.citations.footnotes.length) {
+        lines.push('', '**Footnotes**');
+        result.citations.footnotes.forEach((footnote) => {
+          lines.push(`- ${footnote.number || footnote.id}: ${footnote.text}`);
+        });
+      }
+    });
+    return lines.join('\n').trim();
+  }
+
+  function buildHtmlDocument(payload) {
+    const sections = payload.results
+      .map((result) => {
+        const citationsHtml = renderCitationHtml(result.citations);
+        const sectionHtml = result.html || '<p><em>No content captured.</em></p>';
+        return `<section data-section="${escapeHtmlAttr(slugify(result.sectionLabel))}">
+  <h2>${escapeHtml(result.sectionLabel)}</h2>
+  ${sectionHtml}
+  ${citationsHtml}
+</section>`;
+      })
+      .join('\n\n');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Citation Scraper Export</title>
+    <style>
+      body { font-family: Arial, sans-serif; line-height: 1.6; color: #111827; background: #f8fafc; padding: 2rem; }
+      h1 { margin-top: 0; }
+      section { margin-bottom: 2rem; background: #ffffff; padding: 1.5rem; border-radius: 12px; box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08); }
+      ul { padding-left: 1.25rem; }
+      em { color: #6b7280; }
+      .citations { margin-top: 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Citation Scraper Export</h1>
+    <p><strong>Source:</strong> ${payload.sourceUrl ? `<a href="${escapeHtmlAttr(payload.sourceUrl)}">${escapeHtml(payload.sourceUrl)}</a>` : 'Not specified'}</p>
+    <p><strong>Modes:</strong> ${payload.modes.join(', ') || 'None'}</p>
+    ${sections}
+  </body>
+</html>`;
+  }
+
+  function renderCitationHtml(citations) {
+    let html = '<div class="citations">';
+    if (citations.inline.length) {
+      html += '<h3>Inline citations</h3><ul>';
+      citations.inline.forEach((citation) => {
+        const target = citation.footnoteId ? `#${citation.footnoteId}` : 'unlinked';
+        const detail = citation.tooltip ? ` — ${escapeHtml(citation.tooltip)}` : '';
+        html += `<li>${escapeHtml(citation.number || '—')} → ${escapeHtml(target)}${detail}</li>`;
+      });
+      html += '</ul>';
+    }
+    if (citations.footnotes.length) {
+      html += '<h3>Footnotes</h3><ul>';
+      citations.footnotes.forEach((footnote) => {
+        html += `<li><strong>${escapeHtml(footnote.number || footnote.id)}</strong> ${escapeHtml(footnote.text)}</li>`;
+      });
+      html += '</ul>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function buildBibtexDocument(payload) {
+    const entries = [];
+    payload.results.forEach((result, sectionIndex) => {
+      result.citations.footnotes.forEach((footnote, index) => {
+        const key = `${slugify(result.sectionLabel)}_${sectionIndex + 1}_${index + 1}`.replace(/-/g, '_');
+        entries.push(`@misc{${key},
+  title = {${escapeBibtex(result.sectionLabel)}},
+  note = {${escapeBibtex(footnote.text)}},
+  howpublished = {${escapeBibtex(payload.sourceUrl || 'Unknown source')}},
+  year = {${new Date().getFullYear()}},
+  annote = {Generated by Citation Scraper}
+}`);
+      });
+    });
+    return entries.join('\n\n') || '% No footnotes extracted.';
+  }
+
+  function downloadFile(filename, content, mime) {
+    const blob = new Blob([content], { type: mime });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+  }
+
+  function logMessage(message, type = 'info') {
+    if (!activityLog) {
+      return;
+    }
+    const entry = document.createElement('li');
+    entry.className = 'activity-log__entry';
+    if (type === 'success') {
+      entry.classList.add('activity-log__entry--success');
+    } else if (type === 'error') {
+      entry.classList.add('activity-log__entry--error');
+    } else if (type === 'warning') {
+      entry.classList.add('activity-log__entry--warning');
+    }
+    entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+    activityLog.prepend(entry);
+    while (activityLog.children.length > 60) {
+      activityLog.removeChild(activityLog.lastChild);
+    }
+  }
+
+  function createPill(text) {
+    const pill = document.createElement('span');
+    pill.className = 'pill';
+    pill.textContent = text;
+    return pill;
+  }
+
+  function simulateProcessingDelay(base) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, base + Math.random() * 200);
+    });
+  }
+
+  function slugify(value) {
+    return (value || '')
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'section';
+  }
+
+  function normalizeText(value) {
+    return (value || '').toLowerCase().replace(/\s+/g, ' ').trim();
+  }
+
+  function escapeHtml(value) {
+    return (value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeHtmlAttr(value) {
+    return escapeHtml(value).replace(/`/g, '&#96;');
+  }
+
+  function escapeBibtex(value) {
+    return (value || '')
+      .replace(/\\/g, '\\\\')
+      .replace(/[{}]/g, (match) => `\\${match}`)
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,743 @@
+:root {
+  --bg-surface: #ffffff;
+  --bg-muted: #f4f6fb;
+  --bg-header: linear-gradient(135deg, #2d3a73 0%, #1a1f3d 100%);
+  --border-soft: rgba(32, 42, 90, 0.08);
+  --border-strong: rgba(32, 42, 90, 0.12);
+  --text-primary: #1a1f3d;
+  --text-secondary: #49507a;
+  --text-muted: #7d84a6;
+  --accent: #5061ff;
+  --accent-soft: rgba(80, 97, 255, 0.1);
+  --accent-strong: rgba(80, 97, 255, 0.18);
+  --danger: #d6455d;
+  --warning: #f59e0b;
+  --success: #16a34a;
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --shadow-soft: 0 12px 30px rgba(17, 24, 39, 0.08);
+  --shadow-inner: inset 0 0 0 1px rgba(45, 58, 115, 0.1);
+  --font-sans: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --transition: 150ms ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  background: var(--bg-muted);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+  margin: 0 0 0.35em;
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+p {
+  margin: 0 0 1em;
+}
+
+code,
+pre {
+  font-family: "Fira Code", "SFMono-Regular", "SFMono", "JetBrains Mono", monospace;
+}
+
+pre {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  background: var(--bg-muted);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-soft);
+  overflow-x: auto;
+  white-space: pre-wrap;
+}
+
+.app-header {
+  background: var(--bg-header);
+  color: #f7f9ff;
+  padding: 2.4rem clamp(1.5rem, 3vw, 3rem);
+  box-shadow: var(--shadow-soft);
+}
+
+.app-header__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.branding {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.branding__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 28px;
+}
+
+.branding__copy h1 {
+  font-size: clamp(1.75rem, 4vw, 2.4rem);
+}
+
+.branding__copy p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(247, 249, 255, 0.82);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.version-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.app-layout {
+  max-width: 1280px;
+  margin: 2rem auto 3rem;
+  padding: 0 clamp(1rem, 3vw, 2rem);
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(320px, 380px) 1fr;
+  align-items: start;
+}
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--bg-surface);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid var(--border-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card--tall {
+  height: 100%;
+}
+
+.card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.card__header--tabs {
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid .form-field--stacked {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+input[type="text"],
+input[type="url"],
+textarea {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-strong);
+  background: #fff;
+  font-size: 0.95rem;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 180px;
+}
+
+.param-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.param-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.param-row .delimiter {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.param-remove {
+  padding: 0.35rem 0.65rem;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.button {
+  appearance: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.55rem 1rem;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  box-shadow: none;
+}
+
+.button--primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(80, 97, 255, 0.24);
+}
+
+.button--primary:hover:not(:disabled),
+.button--primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(80, 97, 255, 0.32);
+}
+
+.button--secondary {
+  background: rgba(32, 42, 90, 0.08);
+  color: var(--text-primary);
+}
+
+.button--secondary:hover:not(:disabled),
+.button--secondary:focus-visible {
+  background: rgba(32, 42, 90, 0.14);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent-strong);
+}
+
+.button--ghost:hover:not(:disabled),
+.button--ghost:focus-visible {
+  background: var(--accent-soft);
+}
+
+.button--chip {
+  background: rgba(80, 97, 255, 0.08);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+}
+
+.button--chip:hover,
+.button--chip:focus-visible {
+  background: rgba(80, 97, 255, 0.16);
+}
+
+.toggle-button {
+  background: rgba(32, 42, 90, 0.08);
+  color: var(--text-primary);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.toggle-button[aria-pressed="true"],
+.toggle-button.toggle-button--active {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 10px 18px rgba(80, 97, 255, 0.25);
+}
+
+.mode-toggle {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.section-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0;
+  border: none;
+}
+
+.section-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.section-list .checkbox {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.65rem 0.75rem;
+  background: rgba(80, 97, 255, 0.05);
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(80, 97, 255, 0.18);
+}
+
+.section-list input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  margin-top: 0.25rem;
+}
+
+.section-list .option-text {
+  display: block;
+}
+
+.section-list .option-text small {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.section-picker__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.form-field--inline {
+  flex: 1 1 220px;
+}
+
+.url-preview {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(80, 97, 255, 0.07);
+  border: 1px dashed rgba(80, 97, 255, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.url-preview__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.url-preview__link {
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.control-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.progress-block {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+progress {
+  flex: 1;
+  height: 10px;
+  border-radius: 999px;
+  overflow: hidden;
+  border: none;
+  background: rgba(32, 42, 90, 0.08);
+}
+
+progress::-webkit-progress-bar {
+  background: rgba(32, 42, 90, 0.1);
+}
+
+progress::-webkit-progress-value {
+  background: var(--accent);
+}
+
+progress::-moz-progress-bar {
+  background: var(--accent);
+}
+
+.progress-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.activity-log {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.activity-log__entry {
+  padding: 0.55rem 0.65rem;
+  border-radius: var(--radius-sm);
+  background: rgba(32, 42, 90, 0.05);
+  border: 1px solid rgba(32, 42, 90, 0.08);
+  font-size: 0.85rem;
+}
+
+.activity-log__entry--success {
+  border-color: rgba(22, 163, 74, 0.18);
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--success);
+}
+
+.activity-log__entry--error {
+  border-color: rgba(214, 69, 93, 0.18);
+  background: rgba(214, 69, 93, 0.12);
+  color: var(--danger);
+}
+
+.activity-log__entry--warning {
+  border-color: rgba(245, 158, 11, 0.18);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--warning);
+}
+
+.preview-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.preview-tab {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(32, 42, 90, 0.1);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.preview-tab--active,
+.preview-tab[aria-selected="true"] {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: 0 10px 18px rgba(80, 97, 255, 0.25);
+}
+
+.preview-panes {
+  position: relative;
+}
+
+.preview-pane {
+  display: none;
+}
+
+.preview-pane--active {
+  display: block;
+}
+
+.preview-scroll {
+  max-height: 520px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-right: 0.5rem;
+}
+
+.result-block {
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(32, 42, 90, 0.12);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 6px 16px rgba(17, 24, 39, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.result-block__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.result-block__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(80, 97, 255, 0.12);
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.result-block__html {
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-sm);
+  background: rgba(32, 42, 90, 0.05);
+  border: 1px solid rgba(32, 42, 90, 0.08);
+}
+
+.result-block__html :where(h1, h2, h3, h4, h5) {
+  margin-top: 0;
+}
+
+.result-block__warnings {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--warning);
+  font-size: 0.85rem;
+}
+
+.result-block__warnings li {
+  margin-bottom: 0.35rem;
+}
+
+.empty-state {
+  padding: 1.25rem;
+  text-align: center;
+  color: var(--text-muted);
+  border: 1px dashed rgba(32, 42, 90, 0.18);
+  border-radius: var(--radius-md);
+}
+
+.export-actions {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.validation-summary {
+  margin: 0;
+  font-weight: 600;
+}
+
+.validation-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.validation-entry {
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(32, 42, 90, 0.1);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.validation-entry--ok {
+  border-color: rgba(22, 163, 74, 0.2);
+  background: rgba(22, 163, 74, 0.12);
+  color: var(--success);
+}
+
+.validation-entry--warning {
+  border-color: rgba(245, 158, 11, 0.22);
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--warning);
+}
+
+.validation-entry h4 {
+  margin: 0 0 0.35rem;
+}
+
+.validation-entry ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.preview-table thead {
+  background: rgba(80, 97, 255, 0.08);
+}
+
+.preview-table th,
+.preview-table td {
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid rgba(32, 42, 90, 0.08);
+  text-align: left;
+  vertical-align: top;
+}
+
+.preview-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.preview-table small {
+  display: block;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+.pill--mode {
+  background: rgba(32, 42, 90, 0.08);
+  color: var(--text-secondary);
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 1200px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .panel--configuration {
+    order: 2;
+  }
+
+  .panel--results {
+    order: 1;
+  }
+
+  .card--tall {
+    min-height: 420px;
+  }
+}
+
+@media (max-width: 720px) {
+  .app-header__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .mode-toggle,
+  .control-row,
+  .section-picker__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .preview-scroll {
+    max-height: 420px;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index page that lays out configuration panels, preview tabs, export controls, and validation areas for the scraper
- implement client-side logic to compose URLs, manage presets, run section scraping with citation extraction, and drive previews/exports
- style the interface for responsive use and document configuration plus validation workflows in the README

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68c9f05808608329a2d21ae7337924cf