### PR TITLE
Add ADXS scraping dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# Adxsall
+# ADXS Knowledge Scraper Workspace
+
+This repository provides a browser-based interface for collecting structured content from the ADXS.org knowledge base. The tool works entirely in the browser — no server or backend code is required.
+
+## Getting started
+
+1. **Open the interface**
+   - Double-click `index.html` or open it in your preferred browser via `File → Open`. Modern Chromium-based browsers work best. If your browser blocks `fetch` requests for local files, launch a lightweight static server (for example `python -m http.server`) from the project directory and visit `http://localhost:8000/index.html`.
+
+2. **Configure the scrape**
+   - The **Base URL** defaults to `https://www.adxs.org`. Update it if you want to target a staging or mirrored host.
+   - Choose a **scraping mode**:
+     - **Single page**: captures only the first path in the list (or the base URL when the list is empty).
+     - **Section crawl**: iterates through every path you provide, optimised for anchor-heavy article sections.
+     - **Batch list**: scrapes each path in sequence and reports progress for multi-page collections.
+   - Supply one relative path per line in the **Paths to scrape** area. Leave the field empty to scrape the base URL.
+   - Toggle capture options for inline citations, tooltip text, and footnotes/endnotes.
+
+3. **Run and monitor**
+   - Use **Start** to begin the session. **Pause** temporarily suspends requests; tap **Resume** to continue, or **Stop** to cancel the remainder of the batch.
+   - The progress meter and log tab display active URLs, request outcomes, and any network issues.
+   - The preview tab surfaces key sections from each page, while the statistics tab aggregates counts for sections, citations, tooltips, footnotes, and total words.
+
+4. **Work with the results**
+   - Export buttons generate downloads in JSON, Markdown, HTML, and BibTeX formats. Each export reflects the current batch results only.
+   - Use **Copy summary** to place a compact overview of the batch on your clipboard for quick sharing.
+   - All scraped data stays in memory until you refresh the page or start a new session.
+
+## Notes
+
+- Scraping honours the same-origin policy enforced by your browser. If ADXS.org blocks cross-origin requests, run the interface from a local server or consult the network console for troubleshooting tips.
+- Large batches are throttled slightly between requests to keep the site responsive. Adjust the supplied paths to tune throughput.
+- The UI is responsive and adapts to smaller screens, making it suitable for tablet-based reviews.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ADXS Knowledge Scraper</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="app-header">
+    <div class="branding">
+      <h1>ADXS Knowledge Scraper</h1>
+      <p>Harvest sections, citations, tooltips, and footnotes from ADXS.org content for downstream analysis.</p>
+    </div>
+    <div class="header-meta">
+      <span class="badge">v1.0</span>
+      <span class="status-pill" id="statusPill">Idle</span>
+    </div>
+  </header>
+
+  <main class="app-layout">
+    <section class="panel configuration" aria-labelledby="configuration-heading">
+      <div class="panel-header">
+        <h2 id="configuration-heading">Configuration</h2>
+        <p>Define the scraping batch, select scraping modes, and adjust content capture options.</p>
+      </div>
+      <div class="panel-body">
+        <label class="field">
+          <span class="field-label">Base URL</span>
+          <input type="url" id="baseUrl" value="https://www.adxs.org" placeholder="https://www.adxs.org" required>
+        </label>
+
+        <div class="field">
+          <span class="field-label">Scraping mode</span>
+          <div class="mode-toggle" role="group" aria-label="Scraping mode">
+            <button type="button" class="mode-button active" data-mode="single">Single page</button>
+            <button type="button" class="mode-button" data-mode="section">Section crawl</button>
+            <button type="button" class="mode-button" data-mode="batch">Batch list</button>
+          </div>
+        </div>
+
+        <fieldset class="field options" aria-label="Capture options">
+          <legend>Capture options</legend>
+          <label>
+            <input type="checkbox" id="includeCitations" checked>
+            Inline citations
+          </label>
+          <label>
+            <input type="checkbox" id="includeTooltips" checked>
+            Tooltip text
+          </label>
+          <label>
+            <input type="checkbox" id="includeFootnotes" checked>
+            Footnotes &amp; endnotes
+          </label>
+        </fieldset>
+
+        <label class="field">
+          <span class="field-label">Paths to scrape</span>
+          <textarea id="paths" rows="6" placeholder="/wiki/some-article\n/wiki/another-article"></textarea>
+          <small class="field-hint">Enter one relative path per line. Leave blank for the base URL.</small>
+        </label>
+
+        <div class="control-bar">
+          <button type="button" class="control primary" id="startBtn">Start</button>
+          <button type="button" class="control" id="pauseBtn" disabled>Pause</button>
+          <button type="button" class="control" id="stopBtn" disabled>Stop</button>
+        </div>
+
+        <div class="progress-wrapper" aria-live="polite">
+          <div class="progress-bar" id="progressBar"></div>
+          <div class="progress-meta">
+            <span id="progressText">Awaiting configuration</span>
+            <span id="batchCounter">0 / 0</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel results" aria-labelledby="results-heading">
+      <div class="panel-header results-header">
+        <div>
+          <h2 id="results-heading">Results</h2>
+          <p>Preview captured content, monitor statistics, and review the scraping log.</p>
+        </div>
+        <div class="exports">
+          <button type="button" class="export" data-export="json">Export JSON</button>
+          <button type="button" class="export" data-export="markdown">Export Markdown</button>
+          <button type="button" class="export" data-export="html">Export HTML</button>
+          <button type="button" class="export" data-export="bibtex">Export BibTeX</button>
+          <button type="button" class="export" id="copyClipboard">Copy summary</button>
+        </div>
+      </div>
+      <div class="tabs" role="tablist">
+        <button type="button" role="tab" aria-selected="true" aria-controls="previewPane" class="tab active" data-tab="preview">Preview</button>
+        <button type="button" role="tab" aria-selected="false" aria-controls="statsPane" class="tab" data-tab="stats">Statistics</button>
+        <button type="button" role="tab" aria-selected="false" aria-controls="logsPane" class="tab" data-tab="logs">Logs</button>
+      </div>
+      <div class="tab-panels">
+        <section id="previewPane" class="tab-panel active" role="tabpanel">
+          <div class="empty-state" id="previewEmpty">No pages scraped yet. Start a session to preview content.</div>
+          <div id="previewContent" class="preview-grid" hidden></div>
+        </section>
+        <section id="statsPane" class="tab-panel" role="tabpanel" aria-hidden="true">
+          <dl class="stats-grid">
+            <div>
+              <dt>Pages scraped</dt>
+              <dd id="statPages">0</dd>
+            </div>
+            <div>
+              <dt>Sections captured</dt>
+              <dd id="statSections">0</dd>
+            </div>
+            <div>
+              <dt>Inline citations</dt>
+              <dd id="statCitations">0</dd>
+            </div>
+            <div>
+              <dt>Tooltip notes</dt>
+              <dd id="statTooltips">0</dd>
+            </div>
+            <div>
+              <dt>Footnotes</dt>
+              <dd id="statFootnotes">0</dd>
+            </div>
+            <div>
+              <dt>Total words</dt>
+              <dd id="statWords">0</dd>
+            </div>
+          </dl>
+        </section>
+        <section id="logsPane" class="tab-panel" role="tabpanel" aria-hidden="true">
+          <ul id="logList" class="log-list"></ul>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <p>Built for rapid exploration of the ADXS knowledge base. All data remains on this device until exported.</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,793 @@
+(() => {
+  const state = {
+    mode: 'single',
+    baseUrl: 'https://www.adxs.org',
+    options: {
+      citations: true,
+      tooltips: true,
+      footnotes: true
+    },
+    queue: [],
+    isRunning: false,
+    isPaused: false,
+    processed: 0,
+    total: 0,
+    results: [],
+    logs: []
+  };
+
+  const elements = {};
+
+  document.addEventListener('DOMContentLoaded', () => {
+    cacheElements();
+    attachEventListeners();
+    updateProgress();
+    updateExports();
+    renderPreview();
+    renderStats();
+    renderLogs();
+  });
+
+  function cacheElements() {
+    elements.baseUrl = document.getElementById('baseUrl');
+    elements.paths = document.getElementById('paths');
+    elements.modeButtons = Array.from(document.querySelectorAll('.mode-button'));
+    elements.startBtn = document.getElementById('startBtn');
+    elements.pauseBtn = document.getElementById('pauseBtn');
+    elements.stopBtn = document.getElementById('stopBtn');
+    elements.includeCitations = document.getElementById('includeCitations');
+    elements.includeTooltips = document.getElementById('includeTooltips');
+    elements.includeFootnotes = document.getElementById('includeFootnotes');
+    elements.progressBar = document.getElementById('progressBar');
+    elements.progressText = document.getElementById('progressText');
+    elements.batchCounter = document.getElementById('batchCounter');
+    elements.previewEmpty = document.getElementById('previewEmpty');
+    elements.previewContent = document.getElementById('previewContent');
+    elements.statPages = document.getElementById('statPages');
+    elements.statSections = document.getElementById('statSections');
+    elements.statCitations = document.getElementById('statCitations');
+    elements.statTooltips = document.getElementById('statTooltips');
+    elements.statFootnotes = document.getElementById('statFootnotes');
+    elements.statWords = document.getElementById('statWords');
+    elements.logList = document.getElementById('logList');
+    elements.statusPill = document.getElementById('statusPill');
+    elements.tabButtons = Array.from(document.querySelectorAll('.tab'));
+    elements.tabPanels = Array.from(document.querySelectorAll('.tab-panel'));
+    elements.exportButtons = Array.from(document.querySelectorAll('.export[data-export]'));
+    elements.copyClipboard = document.getElementById('copyClipboard');
+  }
+
+  function attachEventListeners() {
+    elements.modeButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        setMode(btn.dataset.mode);
+      });
+    });
+
+    elements.includeCitations.addEventListener('change', () => {
+      state.options.citations = elements.includeCitations.checked;
+      log(`Inline citation capture ${state.options.citations ? 'enabled' : 'disabled'}.`);
+    });
+
+    elements.includeTooltips.addEventListener('change', () => {
+      state.options.tooltips = elements.includeTooltips.checked;
+      log(`Tooltip capture ${state.options.tooltips ? 'enabled' : 'disabled'}.`);
+    });
+
+    elements.includeFootnotes.addEventListener('change', () => {
+      state.options.footnotes = elements.includeFootnotes.checked;
+      log(`Footnote capture ${state.options.footnotes ? 'enabled' : 'disabled'}.`);
+    });
+
+    elements.startBtn.addEventListener('click', startScrape);
+    elements.pauseBtn.addEventListener('click', togglePause);
+    elements.stopBtn.addEventListener('click', stopScrape);
+
+    elements.tabButtons.forEach((tab) => {
+      tab.addEventListener('click', () => switchTab(tab.dataset.tab));
+    });
+
+    elements.exportButtons.forEach((btn) => {
+      btn.addEventListener('click', () => handleExport(btn.dataset.export));
+    });
+
+    elements.copyClipboard.addEventListener('click', copySummaryToClipboard);
+  }
+
+  function setMode(mode) {
+    if (state.mode === mode) return;
+    state.mode = mode;
+    elements.modeButtons.forEach((btn) => {
+      btn.classList.toggle('active', btn.dataset.mode === mode);
+    });
+    log(`Switched to ${modeLabel(mode)} mode.`);
+  }
+
+  function modeLabel(mode) {
+    switch (mode) {
+      case 'batch':
+        return 'batch';
+      case 'section':
+        return 'section crawl';
+      default:
+        return 'single page';
+    }
+  }
+
+  function startScrape() {
+    if (state.isRunning) {
+      log('A session is already running. Stop it before starting a new one.', 'warning');
+      return;
+    }
+
+    state.baseUrl = (elements.baseUrl.value || 'https://www.adxs.org').trim().replace(/\/$/, '');
+    const rawPaths = elements.paths.value
+      .split(/\n+/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    if (rawPaths.length === 0) {
+      rawPaths.push('');
+    }
+
+    let queue;
+    if (state.mode === 'single') {
+      queue = [buildUrl(rawPaths[0])];
+      if (rawPaths.length > 1) {
+        log('Single page mode only scrapes the first path provided. Additional entries were ignored.', 'warning');
+      }
+    } else {
+      queue = rawPaths.map((path) => buildUrl(path));
+    }
+
+    state.queue = queue;
+    state.total = queue.length;
+    state.processed = 0;
+    state.results = [];
+    state.logs = [];
+    state.isRunning = true;
+    state.isPaused = false;
+
+    elements.pauseBtn.disabled = false;
+    elements.pauseBtn.textContent = 'Pause';
+    elements.stopBtn.disabled = false;
+    elements.startBtn.disabled = true;
+
+    updateStatus('active', 'Running');
+    updateProgress();
+    updateExports();
+    renderLogs();
+    renderPreview();
+    renderStats();
+    log(`Session started in ${modeLabel(state.mode)} mode targeting ${state.total} page${state.total === 1 ? '' : 's'}.`);
+    processQueue();
+  }
+
+  function buildUrl(path) {
+    if (!path) {
+      return state.baseUrl;
+    }
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+    const cleanedPath = path.startsWith('/') ? path : `/${path}`;
+    return `${state.baseUrl}${cleanedPath}`;
+  }
+
+  function togglePause() {
+    if (!state.isRunning) return;
+    state.isPaused = !state.isPaused;
+    if (state.isPaused) {
+      elements.pauseBtn.textContent = 'Resume';
+      updateStatus('paused', 'Paused');
+      log('Scraping paused.');
+    } else {
+      elements.pauseBtn.textContent = 'Pause';
+      updateStatus('active', 'Running');
+      log('Scraping resumed.');
+      processQueue();
+    }
+  }
+
+  function stopScrape() {
+    if (!state.isRunning) return;
+    state.isRunning = false;
+    state.isPaused = false;
+    state.queue = [];
+    elements.startBtn.disabled = false;
+    elements.pauseBtn.disabled = true;
+    elements.stopBtn.disabled = true;
+    elements.pauseBtn.textContent = 'Pause';
+    updateStatus('idle', 'Stopped');
+    updateProgress();
+    log('Session stopped by user.');
+  }
+
+  async function processQueue() {
+    if (!state.isRunning || state.isPaused) {
+      return;
+    }
+
+    const nextUrl = state.queue.shift();
+    if (!nextUrl) {
+      finishSession();
+      return;
+    }
+
+    updateProgress(nextUrl);
+
+    try {
+      log(`Fetching ${nextUrl}`);
+      const result = await scrapeUrl(nextUrl);
+      state.results.push(result);
+      state.processed += 1;
+      updateProgress(nextUrl);
+      renderPreview();
+      renderStats();
+      updateExports();
+      log(`Captured ${result.sections.length} section${result.sections.length === 1 ? '' : 's'} from ${result.title}.`, 'success');
+    } catch (error) {
+      state.processed += 1;
+      updateProgress(nextUrl);
+      log(`Failed to fetch ${nextUrl}: ${error.message}`, 'error');
+    }
+
+    if (state.queue.length > 0) {
+      await delay(250);
+      processQueue();
+    } else {
+      finishSession();
+    }
+  }
+
+  function finishSession() {
+    if (!state.isRunning) return;
+    state.isRunning = false;
+    state.isPaused = false;
+    elements.startBtn.disabled = false;
+    elements.pauseBtn.disabled = true;
+    elements.stopBtn.disabled = true;
+    elements.pauseBtn.textContent = 'Pause';
+    updateStatus('idle', 'Completed');
+    updateProgress();
+    renderLogs();
+    log('Scraping session completed.');
+  }
+
+  async function scrapeUrl(url) {
+    const response = await fetch(url, {
+      method: 'GET',
+      mode: 'cors',
+      credentials: 'omit'
+    });
+
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+
+    const html = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(html, 'text/html');
+    const main = doc.querySelector('main') || doc.querySelector('article') || doc.body;
+    const title = (doc.querySelector('h1') || doc.querySelector('title'))?.textContent?.trim() || url;
+
+    const sections = collectSections(main, title);
+    const inlineCitations = state.options.citations ? collectInlineCitations(main) : [];
+    const tooltips = state.options.tooltips ? collectTooltips(main) : [];
+    const footnotes = state.options.footnotes ? collectFootnotes(doc) : [];
+
+    const wordCount = main.textContent
+      .replace(/\s+/g, ' ')
+      .trim()
+      .split(' ')
+      .filter(Boolean).length;
+
+    return {
+      url,
+      title,
+      fetchedAt: new Date().toISOString(),
+      sections,
+      inlineCitations,
+      tooltips,
+      footnotes,
+      stats: {
+        sections: sections.length,
+        citations: inlineCitations.length,
+        tooltips: tooltips.length,
+        footnotes: footnotes.length,
+        words: wordCount
+      },
+      rawHtml: main.innerHTML
+    };
+  }
+
+  function collectSections(root, fallbackTitle) {
+    const sections = [];
+    const structured = Array.from(root.querySelectorAll('section, article'));
+
+    if (structured.length) {
+      structured.forEach((section, index) => {
+        sections.push(sectionToRecord(section, index + 1));
+      });
+    } else {
+      const headings = Array.from(root.querySelectorAll('h2, h3, h4'));
+      if (headings.length === 0) {
+        sections.push({
+          id: 'section-1',
+          heading: fallbackTitle,
+          text: root.textContent.trim(),
+          html: root.innerHTML.trim()
+        });
+      } else {
+        headings.forEach((heading, index) => {
+          const content = collectFollowingSiblings(heading);
+          sections.push({
+            id: heading.id || `section-${index + 1}`,
+            heading: heading.textContent.trim(),
+            text: content.textContent.trim(),
+            html: content.innerHTML.trim()
+          });
+        });
+      }
+    }
+
+    return sections;
+  }
+
+  function sectionToRecord(section, index) {
+    const heading = section.querySelector('h2, h3, h4, h5, h6');
+    return {
+      id: section.id || `section-${index}`,
+      heading: heading ? heading.textContent.trim() : `Section ${index}`,
+      text: section.textContent.trim(),
+      html: section.innerHTML.trim()
+    };
+  }
+
+  function collectFollowingSiblings(heading) {
+    const container = document.createElement('div');
+    let sibling = heading.nextElementSibling;
+    while (sibling && !/^H[2-4]$/.test(sibling.tagName)) {
+      container.appendChild(sibling.cloneNode(true));
+      sibling = sibling.nextElementSibling;
+    }
+    return container;
+  }
+
+  function collectInlineCitations(root) {
+    const nodes = Array.from(
+      root.querySelectorAll('sup, a[rel="footnote"], a[href*="#cite"], a[href*="#footnote"], a[href*="#fn"], span.citation')
+    );
+
+    const citations = nodes
+      .map((node, index) => {
+        const anchor = node.tagName === 'SUP' ? node.querySelector('a') || node : node;
+        const href = anchor.getAttribute('href') || '';
+        const text = anchor.textContent.trim();
+        if (!text) {
+          return null;
+        }
+        return {
+          id: anchor.id || node.id || `citation-${index + 1}`,
+          text,
+          href,
+          context: node.closest('p, li')?.textContent?.trim().slice(0, 240) || ''
+        };
+      })
+      .filter(Boolean);
+
+    const unique = [];
+    const seen = new Set();
+    citations.forEach((item) => {
+      const key = `${item.text}|${item.href}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        unique.push(item);
+      }
+    });
+
+    return unique;
+  }
+
+  function collectTooltips(root) {
+    const nodes = Array.from(root.querySelectorAll('[data-tooltip], [title], abbr[title], span.tooltip'));
+    return nodes
+      .map((node, index) => {
+        const tooltip = node.getAttribute('data-tooltip') || node.getAttribute('title');
+        if (!tooltip) return null;
+        return {
+          id: node.id || `tooltip-${index + 1}`,
+          text: tooltip.trim(),
+          context: node.textContent.trim()
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function collectFootnotes(doc) {
+    const selectors = [
+      'ol.footnotes li',
+      'section.footnotes li',
+      'aside.footnotes li',
+      'div.footnote',
+      'li.footnote',
+      '[id^="fn"]',
+      '[id^="note"]',
+      '[role="note"]'
+    ];
+
+    const nodes = selectors.flatMap((selector) => Array.from(doc.querySelectorAll(selector)));
+    const unique = [];
+    const seen = new Set();
+
+    nodes.forEach((node, index) => {
+      if (node.tagName && node.tagName.toLowerCase() === 'a') {
+        return;
+      }
+      const id = node.id || node.getAttribute('data-id') || `footnote-${index + 1}`;
+      if (seen.has(id)) return;
+      seen.add(id);
+      unique.push({
+        id,
+        text: node.textContent.trim(),
+        html: node.innerHTML.trim()
+      });
+    });
+
+    return unique;
+  }
+
+  function switchTab(tabName) {
+    elements.tabButtons.forEach((btn) => {
+      const isActive = btn.dataset.tab === tabName;
+      btn.classList.toggle('active', isActive);
+      btn.setAttribute('aria-selected', String(isActive));
+    });
+
+    elements.tabPanels.forEach((panel) => {
+      const isActive = panel.id === `${tabName}Pane`;
+      panel.classList.toggle('active', isActive);
+      panel.setAttribute('aria-hidden', String(!isActive));
+    });
+  }
+
+  function updateProgress(activeUrl) {
+    const total = state.total || 0;
+    const processed = state.processed || 0;
+    const current = activeUrl ? Math.min(processed, total) : processed;
+    const progress = total === 0 ? 0 : Math.round((current / total) * 100);
+    elements.progressBar.style.width = `${progress}%`;
+    let activeLabel = 'Processing';
+    if (activeUrl) {
+      try {
+        const url = new URL(activeUrl);
+        activeLabel = url.pathname || url.href;
+      } catch (error) {
+        activeLabel = activeUrl;
+      }
+    }
+    elements.progressText.textContent = state.isRunning
+      ? activeLabel
+      : processed === 0
+      ? 'Awaiting configuration'
+      : 'Session complete';
+    elements.batchCounter.textContent = `${Math.min(processed, total)} / ${total}`;
+  }
+
+  function updateStatus(type, label) {
+    elements.statusPill.textContent = label;
+    let background;
+    switch (type) {
+      case 'active':
+        background = 'rgba(56, 189, 248, 0.2)';
+        break;
+      case 'paused':
+        background = 'rgba(250, 204, 21, 0.25)';
+        break;
+      case 'idle':
+      default:
+        background = 'rgba(148, 163, 184, 0.2)';
+    }
+    elements.statusPill.style.background = background;
+  }
+
+  function renderPreview() {
+    const container = elements.previewContent;
+    if (state.results.length === 0) {
+      elements.previewEmpty.hidden = false;
+      container.hidden = true;
+      container.innerHTML = '';
+      return;
+    }
+
+    elements.previewEmpty.hidden = true;
+    container.hidden = false;
+
+    container.innerHTML = state.results
+      .map((result) => {
+        let hostname = '';
+        try {
+          hostname = new URL(result.url).hostname;
+        } catch (error) {
+          hostname = 'adxs.org';
+        }
+
+        const sectionPreview = result.sections
+          .slice(0, 3)
+          .map(
+            (section) => `
+              <section>
+                <h4>${escapeHtml(section.heading)}</h4>
+                <p>${escapeHtml(section.text.slice(0, 220))}${section.text.length > 220 ? '…' : ''}</p>
+              </section>
+            `
+          )
+          .join('');
+
+        return `
+          <article class="preview-card">
+            <header>
+              <h3>${escapeHtml(result.title)}</h3>
+              <div class="metadata">
+                <span>${escapeHtml(hostname)}</span>
+                <span>${result.stats.sections} section${result.stats.sections === 1 ? '' : 's'}</span>
+                <span>${result.stats.words} words</span>
+              </div>
+            </header>
+            ${sectionPreview}
+            <footer>
+              <a href="${result.url}" target="_blank" rel="noopener">Open on ADXS.org</a>
+            </footer>
+          </article>
+        `;
+      })
+      .join('');
+  }
+
+  function renderStats() {
+    const totals = state.results.reduce(
+      (acc, result) => {
+        acc.pages += 1;
+        acc.sections += result.stats.sections;
+        acc.citations += result.stats.citations;
+        acc.tooltips += result.stats.tooltips;
+        acc.footnotes += result.stats.footnotes;
+        acc.words += result.stats.words;
+        return acc;
+      },
+      { pages: 0, sections: 0, citations: 0, tooltips: 0, footnotes: 0, words: 0 }
+    );
+
+    elements.statPages.textContent = totals.pages;
+    elements.statSections.textContent = totals.sections;
+    elements.statCitations.textContent = totals.citations;
+    elements.statTooltips.textContent = totals.tooltips;
+    elements.statFootnotes.textContent = totals.footnotes;
+    elements.statWords.textContent = totals.words.toLocaleString();
+  }
+
+  function renderLogs() {
+    elements.logList.innerHTML = state.logs
+      .slice(-120)
+      .map(
+        (entry) => `
+          <li class="log-entry" data-type="${entry.type}">
+            <span>${escapeHtml(entry.message)}</span>
+            <time datetime="${entry.timestamp}">${formatTimestamp(entry.timestamp)}</time>
+          </li>
+        `
+      )
+      .join('');
+  }
+
+  function log(message, type = 'info') {
+    const entry = {
+      message,
+      type,
+      timestamp: new Date().toISOString()
+    };
+    state.logs.push(entry);
+    renderLogs();
+  }
+
+  function updateExports() {
+    const disabled = state.results.length === 0;
+    elements.exportButtons.forEach((btn) => {
+      btn.disabled = disabled;
+    });
+    elements.copyClipboard.disabled = disabled;
+  }
+
+  function handleExport(format) {
+    if (state.results.length === 0) return;
+
+    switch (format) {
+      case 'json':
+        downloadFile('adxs-scrape.json', JSON.stringify(state.results, null, 2), 'application/json');
+        break;
+      case 'markdown':
+        downloadFile('adxs-scrape.md', convertResultsToMarkdown(state.results), 'text/markdown');
+        break;
+      case 'html':
+        downloadFile('adxs-scrape.html', convertResultsToHtml(state.results), 'text/html');
+        break;
+      case 'bibtex':
+        downloadFile('adxs-scrape.bib', convertResultsToBibTeX(state.results), 'application/x-bibtex');
+        break;
+      default:
+        log(`Unknown export format: ${format}`, 'error');
+    }
+  }
+
+  function convertResultsToMarkdown(results) {
+    const lines = ['# ADXS scrape results', '', `Generated: ${new Date().toISOString()}`, ''];
+    results.forEach((result) => {
+      lines.push(`## ${result.title}`);
+      lines.push(result.url);
+      lines.push('');
+      result.sections.forEach((section) => {
+        lines.push(`### ${section.heading}`);
+        lines.push(section.text);
+        lines.push('');
+      });
+      if (result.inlineCitations.length) {
+        lines.push('#### Inline citations');
+        result.inlineCitations.forEach((citation) => {
+          lines.push(`- ${citation.text}${citation.href ? ` (${citation.href})` : ''}`);
+        });
+        lines.push('');
+      }
+      if (result.footnotes.length) {
+        lines.push('#### Footnotes');
+        result.footnotes.forEach((footnote) => {
+          lines.push(`- ${footnote.text}`);
+        });
+        lines.push('');
+      }
+    });
+    return lines.join('\n');
+  }
+
+  function convertResultsToHtml(results) {
+    const sections = results
+      .map((result) => {
+        const sectionsHtml = result.sections
+          .map(
+            (section) => `
+            <section id="${section.id}">
+              <h3>${escapeHtml(section.heading)}</h3>
+              <div>${section.html}</div>
+            </section>
+          `
+          )
+          .join('\n');
+
+        const citationsHtml = result.inlineCitations.length
+          ? `<section class="citations"><h4>Inline citations</h4><ul>${result.inlineCitations
+              .map((citation) => `<li>${escapeHtml(citation.text)}${
+                citation.href ? ` (<a href="${citation.href}">${escapeHtml(citation.href)}</a>)` : ''
+              }</li>`)
+              .join('')}</ul></section>`
+          : '';
+
+        const footnotesHtml = result.footnotes.length
+          ? `<section class="footnotes"><h4>Footnotes</h4><ul>${result.footnotes
+              .map((footnote) => `<li>${footnote.html}</li>`)
+              .join('')}</ul></section>`
+          : '';
+
+        return `
+        <article class="page-result">
+          <header>
+            <h2>${escapeHtml(result.title)}</h2>
+            <p><a href="${result.url}">${result.url}</a></p>
+          </header>
+          ${sectionsHtml}
+          ${citationsHtml}
+          ${footnotesHtml}
+        </article>`;
+      })
+      .join('\n');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>ADXS scrape export</title>
+<style>
+body { font-family: Inter, system-ui, -apple-system, "Segoe UI", sans-serif; margin: 2rem auto; max-width: 960px; line-height: 1.6; }
+h1, h2, h3, h4 { font-weight: 600; }
+.page-result { margin-bottom: 3rem; border-bottom: 1px solid #cbd5f5; padding-bottom: 2rem; }
+.page-result header h2 { margin-bottom: 0.25rem; }
+.citations ul, .footnotes ul { padding-left: 1.2rem; }
+</style>
+</head>
+<body>
+<h1>ADXS scrape results</h1>
+<p>Generated: ${new Date().toISOString()}</p>
+${sections}
+</body>
+</html>`;
+  }
+
+  function convertResultsToBibTeX(results) {
+    return results
+      .map((result, index) => {
+        const keyBase = result.title
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '')
+          .slice(0, 40);
+        const key = keyBase || `adxs-${index + 1}`;
+        return `@online{${key},
+  title = {${result.title}},
+  url = {${result.url}},
+  note = {Captured ${result.stats.sections} sections, ${result.stats.citations} citations, ${result.stats.footnotes} footnotes},
+  year = {${new Date(result.fetchedAt).getFullYear()}},
+  urldate = {${result.fetchedAt.split('T')[0]}}
+}`;
+      })
+      .join('\n\n');
+  }
+
+  async function copySummaryToClipboard() {
+    if (state.results.length === 0) return;
+    const summary = state.results
+      .map(
+        (result) => `${result.title} — ${result.url}\nSections: ${result.stats.sections}, Citations: ${result.stats.citations}, Footnotes: ${result.stats.footnotes}`
+      )
+      .join('\n\n');
+
+    try {
+      await navigator.clipboard.writeText(summary);
+      log('Summary copied to clipboard.', 'success');
+    } catch (error) {
+      fallbackCopy(summary);
+    }
+  }
+
+  function fallbackCopy(text) {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textarea);
+    log('Summary copied using fallback method.', 'success');
+  }
+
+  function downloadFile(filename, content, mime) {
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    log(`${filename} export generated.`, 'success');
+  }
+
+  function escapeHtml(value) {
+    return (value ?? '')
+      .toString()
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function formatTimestamp(timestamp) {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+
+  function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,467 @@
+:root {
+  color-scheme: light dark;
+  --bg-gradient-start: #0f172a;
+  --bg-gradient-end: #1e293b;
+  --panel-bg: rgba(15, 23, 42, 0.75);
+  --panel-border: rgba(148, 163, 184, 0.2);
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --accent: #38bdf8;
+  --accent-strong: #0284c7;
+  --success: #22c55e;
+  --warning: #f97316;
+  --danger: #ef4444;
+  --shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding: 2.5rem 1.75rem 2rem;
+}
+
+h1, h2, h3 {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+a {
+  color: var(--accent);
+}
+
+a:hover {
+  color: var(--accent-strong);
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.branding p {
+  max-width: 48ch;
+}
+
+.header-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.badge {
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--accent);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.status-pill {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.6fr);
+  gap: 2rem;
+  flex: 1;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 1.5rem;
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(12px);
+}
+
+.panel-header {
+  margin-bottom: 1.5rem;
+}
+
+.panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field-label {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.field-hint {
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 0.75rem;
+}
+
+input[type="url"],
+textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.7);
+  color: inherit;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="url"]:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.mode-toggle {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.mode-button {
+  padding: 0.65rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(30, 41, 59, 0.7);
+  color: inherit;
+  font-weight: 500;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.mode-button.active {
+  border-color: rgba(56, 189, 248, 0.9);
+  background: rgba(56, 189, 248, 0.2);
+  transform: translateY(-1px);
+}
+
+.options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.5rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.options label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.control-bar {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.control {
+  flex: 1;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: none;
+  font-weight: 600;
+  background: rgba(30, 41, 59, 0.8);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.control.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.25);
+}
+
+.control:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.control:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.progress-wrapper {
+  position: relative;
+  border-radius: 0.85rem;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.75rem 1rem;
+}
+
+.progress-bar {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(90deg, rgba(56, 189, 248, 0.25), rgba(56, 189, 248, 0.6));
+  transition: width 0.3s ease;
+}
+
+.progress-meta {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+}
+
+.results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.exports {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.export {
+  padding: 0.55rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(30, 41, 59, 0.7);
+  color: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.export:hover:not(:disabled) {
+  border-color: rgba(56, 189, 248, 0.8);
+  background: rgba(56, 189, 248, 0.15);
+}
+
+.export:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.tabs {
+  display: inline-flex;
+  padding: 0.35rem;
+  border-radius: 0.85rem;
+  background: rgba(15, 23, 42, 0.5);
+  margin-bottom: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.tab {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-weight: 500;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.7rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.tab.active {
+  background: rgba(56, 189, 248, 0.2);
+  color: var(--text-primary);
+}
+
+.tab-panel {
+  display: none;
+}
+
+.tab-panel.active {
+  display: block;
+}
+
+.preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.preview-card {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.preview-card header h3 {
+  font-size: 1.05rem;
+}
+
+.preview-card .metadata {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.preview-card section {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem;
+}
+
+.stats-grid dt {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.6);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stats-grid dd {
+  margin: 0;
+  font-size: 1.85rem;
+  font-weight: 600;
+}
+
+.log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.log-entry {
+  background: rgba(15, 23, 42, 0.5);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.9rem;
+  padding: 0.75rem 1rem;
+  font-size: 0.85rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.log-entry[data-type="error"] {
+  border-color: rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.15);
+}
+
+.log-entry[data-type="success"] {
+  border-color: rgba(34, 197, 94, 0.4);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.log-entry[data-type="warning"] {
+  border-color: rgba(250, 204, 21, 0.35);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.log-entry time {
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.4);
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.app-footer {
+  margin-top: 2.5rem;
+  text-align: center;
+  color: rgba(226, 232, 240, 0.6);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1100px) {
+  body {
+    padding: 2rem 1.5rem 1.5rem;
+  }
+
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .results {
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .exports {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .control-bar {
+    flex-direction: column;
+  }
+
+  .control {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new index.html experience with configuration, results tabs, and export actions
- implement styles.css for gradient styling, responsive layout, and component visuals
- build script.js to manage scraping workflow, fetch ADXS.org pages, parse structured data, and drive exports
- document usage in README.md including running locally, configuring modes, and exporting output

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68ce279c83d48329b1c580ba7dc3f969