### PR TITLE
Add validation pane and export self-check summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,11 +94,12 @@
           <button type="button" class="export" id="copyClipboard">Copy summary</button>
         </div>
       </div>
-      <div class="tabs" role="tablist">
-        <button type="button" role="tab" aria-selected="true" aria-controls="previewPane" class="tab active" data-tab="preview">Preview</button>
-        <button type="button" role="tab" aria-selected="false" aria-controls="statsPane" class="tab" data-tab="stats">Statistics</button>
-        <button type="button" role="tab" aria-selected="false" aria-controls="logsPane" class="tab" data-tab="logs">Logs</button>
-      </div>
+        <div class="tabs" role="tablist">
+          <button type="button" role="tab" aria-selected="true" aria-controls="previewPane" class="tab active" data-tab="preview">Preview</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="statsPane" class="tab" data-tab="stats">Statistics</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="validationPane" class="tab" data-tab="validation">Validation</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="logsPane" class="tab" data-tab="logs">Logs</button>
+        </div>
       <div class="tab-panels">
         <section id="previewPane" class="tab-panel active" role="tabpanel">
           <div class="empty-state" id="previewEmpty">No pages scraped yet. Start a session to preview content.</div>
@@ -131,6 +132,18 @@
               <dd id="statWords">0</dd>
             </div>
           </dl>
+        </section>
+        <section id="validationPane" class="tab-panel" role="tabpanel" aria-hidden="true">
+          <div class="validation-overview">
+            <div class="validation-status" id="validationStatus">Awaiting results</div>
+            <div class="validation-counts">
+              <span class="count pass">Pass <strong id="validationPassCount">0</strong></span>
+              <span class="count warning">Warnings <strong id="validationWarnCount">0</strong></span>
+              <span class="count error">Errors <strong id="validationErrorCount">0</strong></span>
+            </div>
+          </div>
+          <div class="empty-state" id="validationEmpty">Run a scrape to populate validation results.</div>
+          <ul id="validationList" class="validation-list" hidden></ul>
         </section>
         <section id="logsPane" class="tab-panel" role="tabpanel" aria-hidden="true">
           <ul id="logList" class="log-list"></ul>

--- a/styles.css
+++ b/styles.css
@@ -373,6 +373,149 @@ textarea {
   font-weight: 600;
 }
 
+.validation-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.validation-status {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.validation-status.pass {
+  border-color: rgba(34, 197, 94, 0.45);
+  color: var(--success);
+}
+
+.validation-status.warning {
+  border-color: rgba(250, 204, 21, 0.45);
+  color: var(--warning);
+}
+
+.validation-status.error {
+  border-color: rgba(239, 68, 68, 0.45);
+  color: var(--danger);
+}
+
+.validation-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.validation-counts .count strong {
+  margin-left: 0.35rem;
+  color: var(--text-primary);
+}
+
+.validation-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.validation-item {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.45);
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.validation-item.pass {
+  border-color: rgba(34, 197, 94, 0.35);
+  background: rgba(34, 197, 94, 0.12);
+}
+
+.validation-item.warning {
+  border-color: rgba(250, 204, 21, 0.35);
+  background: rgba(250, 204, 21, 0.12);
+}
+
+.validation-item.error {
+  border-color: rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.12);
+}
+
+.validation-item-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.validation-badge {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  flex-shrink: 0;
+}
+
+.validation-item.pass .validation-badge {
+  border-color: rgba(34, 197, 94, 0.55);
+  color: var(--success);
+}
+
+.validation-item.warning .validation-badge {
+  border-color: rgba(250, 204, 21, 0.55);
+  color: var(--warning);
+}
+
+.validation-item.error .validation-badge {
+  border-color: rgba(239, 68, 68, 0.55);
+  color: var(--danger);
+}
+
+.validation-message {
+  flex: 1;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.validation-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.validation-meta .meta-separator {
+  margin: 0 0.25rem;
+  color: rgba(226, 232, 240, 0.45);
+}
+
+.validation-details {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.validation-details span {
+  display: block;
+}
+
 .log-list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a Validation tab that surfaces severity counts and individual findings for citation checks
- implement a citation/tooltip/footnote cross-check routine with limitation warnings when capture options are disabled
- include validation outcomes in runtime logs, clipboard summaries, and JSON/Markdown/HTML exports

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68ce46eb784483298065a02b5fb2607d