### PR TITLE
Add sitemap selection UI and mobile usage guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,33 +1,96 @@
 # ADXS Knowledge Scraper Workspace
 
-This repository provides a browser-based interface for collecting structured content from the ADXS.org knowledge base. The tool works entirely in the browser — no server or backend code is required.
+An interactive browser application for harvesting structured content from the ADXS.org knowledge base. The UI combines a sitemap-driven section selector, citation and tooltip validation, custom document assembly, and responsive styling so it stays usable on large desktop monitors and smaller Android screens.
 
-## Getting started
+> **Why a helper server?** ADXS.org does not send permissive CORS headers, so browsers block direct cross-origin `fetch` calls. The included Node helper server proxies requests locally, giving the front-end safe access to the remote HTML.
 
-1. **Open the interface**
-   - Double-click `index.html` or open it in your preferred browser via `File → Open`. Modern Chromium-based browsers work best. If your browser blocks `fetch` requests for local files, launch a lightweight static server (for example `python -m http.server`) from the project directory and visit `http://localhost:8000/index.html`.
+## Prerequisites
 
-2. **Configure the scrape**
-   - The **Base URL** defaults to `https://www.adxs.org`. Update it if you want to target a staging or mirrored host.
-   - Choose a **scraping mode**:
-     - **Single page**: captures only the first path in the list (or the base URL when the list is empty).
-     - **Section crawl**: iterates through every path you provide, optimised for anchor-heavy article sections.
-     - **Batch list**: scrapes each path in sequence and reports progress for multi-page collections.
-   - Supply one relative path per line in the **Paths to scrape** area. Leave the field empty to scrape the base URL.
-   - Toggle capture options for inline citations, tooltip text, and footnotes/endnotes.
+- [Node.js 18+](https://nodejs.org/) (includes `npm` and the global `fetch` API used by the proxy)
+- A modern Chromium- or Firefox-based browser. Chrome/Firefox for Android work well when you follow the mobile guide below.
 
-3. **Run and monitor**
-   - Use **Start** to begin the session. **Pause** temporarily suspends requests; tap **Resume** to continue, or **Stop** to cancel the remainder of the batch.
-   - The progress meter and log tab display active URLs, request outcomes, and any network issues.
-   - The preview tab surfaces key sections from each page, while the statistics tab aggregates counts for sections, citations, tooltips, footnotes, and total words.
+## Guided setup (desktop & laptop)
 
-4. **Work with the results**
-   - Export buttons generate downloads in JSON, Markdown, HTML, and BibTeX formats. Each export reflects the current batch results only.
-   - Use **Copy summary** to place a compact overview of the batch on your clipboard for quick sharing.
-   - All scraped data stays in memory until you refresh the page or start a new session.
+1. **Download the project** – clone the repository or unzip it into a folder on your machine.
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   This pulls in Express (for the proxy/static server) and its minimal dependency tree.
+3. **Start the helper server**
+   ```bash
+   npm run dev
+   ```
+   Leave this terminal window running. The server listens on [http://localhost:3000](http://localhost:3000), serves the UI, and exposes `/api/fetch` for proxied ADXS requests.
+4. **Open the UI** – visit `http://localhost:3000` in your browser. The blue proxy warning in the configuration panel disappears once the app detects it is being served over HTTP/HTTPS.
 
-## Notes
+## Using the sitemap selector
 
-- Scraping honours the same-origin policy enforced by your browser. If ADXS.org blocks cross-origin requests, run the interface from a local server or consult the network console for troubleshooting tips.
-- Large batches are throttled slightly between requests to keep the site responsive. Adjust the supplied paths to tune throughput.
-- The UI is responsive and adapts to smaller screens, making it suitable for tablet-based reviews.
+The **Site structure** panel (left column) loads the live ADXS sitemap so you can curate a batch before scraping:
+
+- Click **Refresh sitemap** after changing the base URL or language. The panel automatically expands the categories pulled from `/en/sitemap` (or `/de/sitemap` if you switch languages).
+- Tick the checkboxes next to sections and subsections to add them to the scraping queue. Chips under the summary show the most recent selections.
+- Use the toolbar buttons to select everything, clear the current selection, or expand/collapse the category groups. Group-level buttons let you capture or clear one topic cluster at a time.
+- The selections feed directly into the next run. You can still paste manual paths in the “Paths to scrape” textarea—both sources are merged and de-duplicated when you click **Start**.
+
+## Running a scrape
+
+1. **Base URL** – defaults to `https://www.adxs.org`. Point it at a mirrored host if required.
+2. **Scraping mode** – choose between *Single page*, *Section crawl*, or *Batch list*. Single mode only processes the first queued path; the other modes walk every entry.
+3. **Paths to scrape** – optionally add one relative or absolute URL per line. Leave the field empty to rely entirely on the sitemap selection.
+4. **Capture options** – toggle inline citations, tooltip text (including `data-tippy-content` popovers), and footnotes/endnotes. Leaving them enabled maximises validation coverage.
+5. **Controls** – click **Start** to begin. **Pause** temporarily suspends the queue; click again to resume. **Stop** cancels the remaining URLs.
+6. **Monitor progress** – the tabs in the Results panel show previews, aggregate statistics, validation findings, assembled documents, and the fetch log. Export buttons become active once at least one page succeeds.
+
+## Building custom documents
+
+Use the **Documents** tab after a run finishes:
+
+1. Expand a page, tick the sections you want, and repeat across as many pages as required.
+2. Provide a descriptive name and click **Create document from selected sections**. The app stores the document (including metadata, word counts, and originating pages) in memory.
+3. Repeat to build multiple focused packets. Remove a document at any time with the **Remove** button.
+4. Export individual documents as Markdown, HTML, or JSON directly from each card.
+
+Selections persist until you clear them or start a new scraping session. The **Clear selection** button in the tab resets the section checkboxes without deleting existing documents.
+
+## Exporting results
+
+The buttons in the **Results** header generate full-batch exports:
+
+- **JSON** – structured data for downstream scripting.
+- **Markdown / HTML** – human-readable summaries with sections, citations, footnotes, and validation notes.
+- **BibTeX** – quick reference entries for bibliographic tools.
+- **Copy summary** – copies a compact per-page overview (counts plus validation status) to the clipboard.
+
+Exports reflect the current batch in memory. Start a new scrape to reset the dataset.
+
+## Android quick start
+
+You can run the helper server and UI directly on an Android device with [Termux](https://termux.dev/en/):
+
+1. Install Termux from F-Droid or the Termux GitHub releases (the Play Store build is outdated).
+2. Open Termux and install Node.js:
+   ```bash
+   pkg install nodejs-lts git
+   ```
+3. Clone or copy this repository into Termux, then install dependencies:
+   ```bash
+   git clone <your-repo-url>
+   cd <your-repo-folder>
+   npm install
+   ```
+4. Start the helper server:
+   ```bash
+   npm run dev
+   ```
+   Keep Termux in the foreground or run `termux-wake-lock` beforehand to stop Android from suspending the process.
+5. Open Chrome or Firefox on the same device and browse to [http://127.0.0.1:3000](http://127.0.0.1:3000). The layout collapses into a single column, buttons gain larger touch targets, and the sitemap panel remains scrollable with swipe gestures.
+6. When you are finished, switch back to Termux and press `Ctrl+C` to stop the server.
+
+## Troubleshooting
+
+- **“Start the helper server…” warning** – you opened `index.html` directly. Run `npm run dev` and reload via `http://localhost:3000` (or `http://127.0.0.1:3000` on Android).
+- **Sitemap fails to load** – the helper server is required. Ensure it is running, refresh the sitemap, and confirm the terminal logs proxy requests.
+- **Fetch errors or 403s** – verify the helper server output, confirm the target URLs are valid, and respect ADXS.org’s rate limits.
+- **Missing tooltips in validation** – keep the “Tooltip text” option enabled; the validator expects `data-tippy-content` captures to link inline citations with their popover text.
+- **Large batches** – the scraper inserts a short 250 ms delay between requests to avoid overwhelming ADXS.org. Adjust your path list and sitemap selection to control throughput.

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
         <p>Define the scraping batch, select scraping modes, and adjust content capture options.</p>
       </div>
       <div class="panel-body">
+        <div class="inline-warning" id="proxyWarning" role="alert" hidden>
+          Live scraping requires the bundled local helper server. Follow the README steps to run <code>npm install</code> and
+          <code>npm run dev</code>, then reload this page from <code>http://localhost:3000</code>.
+        </div>
         <label class="field">
           <span class="field-label">Base URL</span>
           <input type="url" id="baseUrl" value="https://www.adxs.org" placeholder="https://www.adxs.org" required>
@@ -98,6 +102,7 @@
           <button type="button" role="tab" aria-selected="true" aria-controls="previewPane" class="tab active" data-tab="preview">Preview</button>
           <button type="button" role="tab" aria-selected="false" aria-controls="statsPane" class="tab" data-tab="stats">Statistics</button>
           <button type="button" role="tab" aria-selected="false" aria-controls="validationPane" class="tab" data-tab="validation">Validation</button>
+          <button type="button" role="tab" aria-selected="false" aria-controls="documentsPane" class="tab" data-tab="documents">Documents</button>
           <button type="button" role="tab" aria-selected="false" aria-controls="logsPane" class="tab" data-tab="logs">Logs</button>
         </div>
       <div class="tab-panels">
@@ -145,9 +150,52 @@
           <div class="empty-state" id="validationEmpty">Run a scrape to populate validation results.</div>
           <ul id="validationList" class="validation-list" hidden></ul>
         </section>
+        <section id="documentsPane" class="tab-panel" role="tabpanel" aria-hidden="true">
+          <div class="documents-intro">
+            <p>Select sections from the scraped pages to assemble focused documents. Give each document a clear name so you can
+              export them independently.</p>
+          </div>
+          <div class="empty-state" id="documentsEmpty">Scrape at least one page to unlock section selection.</div>
+          <div id="documentBuilder" class="document-builder" hidden></div>
+          <div class="document-actions" id="documentActions" hidden>
+            <label class="field">
+              <span class="field-label">Document name</span>
+              <input type="text" id="documentName" placeholder="e.g. Diagnostics overview">
+            </label>
+            <button type="button" class="control primary" id="createDocumentBtn">Create document from selected sections</button>
+            <button type="button" class="control" id="clearSelectionBtn">Clear selection</button>
+          </div>
+          <div id="documentList" class="document-list" hidden></div>
+        </section>
         <section id="logsPane" class="tab-panel" role="tabpanel" aria-hidden="true">
           <ul id="logList" class="log-list"></ul>
         </section>
+      </div>
+    </section>
+
+    <section class="panel structure" aria-labelledby="structure-heading">
+      <div class="panel-header">
+        <h2 id="structure-heading">Site structure</h2>
+        <p>Load the ADXS sitemap, explore categories, and choose the sections that should feed the next scrape.</p>
+      </div>
+      <div class="panel-body structure-body">
+        <div class="structure-intro">
+          <p>Selections made here are added to the scraping queue automatically. Combine them with manual paths when you need a
+            custom batch.</p>
+        </div>
+        <div class="structure-toolbar" id="structureActions">
+          <button type="button" class="chip-button" data-action="refresh-structure">Refresh sitemap</button>
+          <button type="button" class="chip-button" data-action="select-all">Select all</button>
+          <button type="button" class="chip-button" data-action="clear-selection">Clear selection</button>
+          <button type="button" class="chip-button" data-action="expand-all">Expand all</button>
+          <button type="button" class="chip-button" data-action="collapse-all">Collapse all</button>
+        </div>
+        <div class="structure-summary">
+          <p id="structureSummaryLabel">Loading sitemap…</p>
+          <div class="structure-chips" id="structureChips"></div>
+        </div>
+        <div id="structureStatus" class="structure-status" role="status" hidden></div>
+        <div id="structureTree" class="structure-tree" role="tree" aria-label="ADXS sitemap"></div>
       </div>
     </section>
   </main>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,832 @@
+{
+  "name": "adxs-knowledge-scraper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "adxs-knowledge-scraper",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.19.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "adxs-knowledge-scraper",
+  "version": "1.0.0",
+  "description": "Interactive ADXS.org scraper UI with local proxy helper",
+  "main": "server.js",
+  "scripts": {
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,7 +1,10 @@
 (() => {
+  const DEFAULT_BASE_URL = 'https://www.adxs.org';
+
   const state = {
     mode: 'single',
-    baseUrl: 'https://www.adxs.org',
+    baseUrl: DEFAULT_BASE_URL,
+    language: 'en',
     options: {
       citations: true,
       tooltips: true,
@@ -13,10 +16,20 @@
     processed: 0,
     total: 0,
     results: [],
-    logs: []
+    logs: [],
+    documents: [],
+    selectedSections: new Map(),
+    siteStructure: [],
+    structureLoading: false,
+    structureError: null,
+    selectedStructureUrls: new Set(),
+    structureOpenGroups: new Set(),
+    structureOrigin: '',
+    structureLanguage: 'en'
   };
 
   const elements = {};
+  let structureRefreshTimer = null;
 
   document.addEventListener('DOMContentLoaded', () => {
     cacheElements();
@@ -27,6 +40,11 @@
     renderStats();
     renderValidation();
     renderLogs();
+    renderDocumentBuilder();
+    renderDocuments();
+    updateProxyWarning();
+    renderStructurePanel();
+    loadSiteStructure();
   });
 
   function cacheElements() {
@@ -62,6 +80,19 @@
     elements.validationEmpty = document.getElementById('validationEmpty');
     elements.validationList = document.getElementById('validationList');
     elements.copyClipboard = document.getElementById('copyClipboard');
+    elements.proxyWarning = document.getElementById('proxyWarning');
+    elements.documentBuilder = document.getElementById('documentBuilder');
+    elements.documentActions = document.getElementById('documentActions');
+    elements.documentName = document.getElementById('documentName');
+    elements.createDocumentBtn = document.getElementById('createDocumentBtn');
+    elements.clearSelectionBtn = document.getElementById('clearSelectionBtn');
+    elements.documentsEmpty = document.getElementById('documentsEmpty');
+    elements.documentList = document.getElementById('documentList');
+    elements.structureActions = document.getElementById('structureActions');
+    elements.structureTree = document.getElementById('structureTree');
+    elements.structureSummaryLabel = document.getElementById('structureSummaryLabel');
+    elements.structureChips = document.getElementById('structureChips');
+    elements.structureStatus = document.getElementById('structureStatus');
   }
 
   function attachEventListeners() {
@@ -70,6 +101,12 @@
         setMode(btn.dataset.mode);
       });
     });
+
+    if (elements.baseUrl) {
+      ['change', 'blur'].forEach((eventName) => {
+        elements.baseUrl.addEventListener(eventName, scheduleStructureRefresh);
+      });
+    }
 
     elements.includeCitations.addEventListener('change', () => {
       state.options.citations = elements.includeCitations.checked;
@@ -99,6 +136,671 @@
     });
 
     elements.copyClipboard.addEventListener('click', copySummaryToClipboard);
+
+    if (elements.structureActions) {
+      elements.structureActions.addEventListener('click', handleStructureAction);
+    }
+    if (elements.structureTree) {
+      elements.structureTree.addEventListener('change', handleStructureTreeChange);
+      elements.structureTree.addEventListener('click', handleStructureTreeClick);
+      elements.structureTree.addEventListener('toggle', handleStructureGroupToggle, true);
+    }
+
+    if (elements.documentBuilder) {
+      elements.documentBuilder.addEventListener('change', handleDocumentSelectionChange);
+    }
+    if (elements.createDocumentBtn) {
+      elements.createDocumentBtn.addEventListener('click', createDocumentFromSelection);
+    }
+    if (elements.clearSelectionBtn) {
+      elements.clearSelectionBtn.addEventListener('click', clearSelectedSections);
+    }
+    if (elements.documentList) {
+      elements.documentList.addEventListener('click', handleDocumentListClick);
+    }
+  }
+
+  function scheduleStructureRefresh() {
+    if (structureRefreshTimer) {
+      clearTimeout(structureRefreshTimer);
+    }
+    structureRefreshTimer = setTimeout(() => {
+      loadSiteStructure({ silent: true });
+    }, 600);
+  }
+
+  async function loadSiteStructure(options = {}) {
+    const { silent = false, force = false } = options;
+    let baseValue = elements.baseUrl?.value?.trim() || state.baseUrl || DEFAULT_BASE_URL;
+    if (!baseValue) {
+      baseValue = DEFAULT_BASE_URL;
+    }
+    const origin = extractOrigin(baseValue);
+    const language = deriveLanguageSegment(baseValue);
+
+    if (!force && state.structureOrigin === origin && state.structureLanguage === language && state.siteStructure.length > 0) {
+      if (!silent) {
+        renderStructurePanel();
+      }
+      return;
+    }
+
+    state.structureLoading = true;
+    state.structureError = null;
+    renderStructurePanel();
+
+    try {
+      const sitemapUrl = buildSitemapUrl(origin, language);
+      const response = await fetch(buildProxyUrl(sitemapUrl), {
+        method: 'GET',
+        headers: { Accept: 'text/html,application/xhtml+xml' }
+      });
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+      const html = await response.text();
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
+      const groups = parseSitemapDocument(doc, origin);
+
+      state.siteStructure = groups;
+      state.structureOrigin = origin;
+      state.structureLanguage = language;
+      state.structureOpenGroups = new Set(groups.map((group) => group.key));
+
+      const availableUrls = new Set();
+      groups.forEach((group) => collectGroupUrls(group, availableUrls));
+
+      if (state.selectedStructureUrls.size > 0) {
+        const filtered = Array.from(state.selectedStructureUrls).filter((url) => availableUrls.has(url));
+        const removed = state.selectedStructureUrls.size - filtered.length;
+        state.selectedStructureUrls = new Set(filtered);
+        if (removed > 0 && !silent) {
+          log(
+            `${removed} sitemap selection${removed === 1 ? '' : 's'} were removed because they are not present in the current sitemap.`,
+            'warning'
+          );
+        }
+      }
+
+      if (!silent) {
+        log(
+          `Loaded sitemap (${language.toUpperCase()}) with ${availableUrls.size} section${availableUrls.size === 1 ? '' : 's'}.`,
+          'success'
+        );
+      }
+    } catch (error) {
+      const message =
+        error.message && error.message.includes('Local helper server unavailable')
+          ? 'Run npm run dev and open the app via http://localhost:3000 to load the sitemap.'
+          : `Unable to load sitemap: ${error.message}`;
+      state.structureError = message;
+      if (!silent) {
+        log(message, 'error');
+      }
+    } finally {
+      state.structureLoading = false;
+      renderStructurePanel();
+    }
+  }
+
+  function deriveLanguageSegment(urlValue) {
+    try {
+      const parsed = new URL(urlValue);
+      const parts = parsed.pathname.split('/').filter(Boolean);
+      if (parts.length > 0) {
+        const candidate = parts[0].toLowerCase();
+        if (/^[a-z]{2}$/.test(candidate)) {
+          return candidate;
+        }
+      }
+    } catch (error) {
+      // fall back to default language
+    }
+    return 'en';
+  }
+
+  function extractOrigin(urlValue) {
+    try {
+      const parsed = new URL(urlValue);
+      return parsed.origin;
+    } catch (error) {
+      return new URL(DEFAULT_BASE_URL).origin;
+    }
+  }
+
+  function buildSitemapUrl(origin, language) {
+    const lang = language && language.length ? language : 'en';
+    return new URL(`/${lang}/sitemap`, origin).toString();
+  }
+
+  function parseSitemapDocument(doc, origin) {
+    const main = doc.querySelector('main') || doc.body;
+    if (!main) {
+      return [];
+    }
+    const headings = Array.from(main.querySelectorAll('h2'));
+    const groups = [];
+    headings.forEach((heading, index) => {
+      const list = findNextListSibling(heading);
+      if (!list) {
+        return;
+      }
+      const title = normaliseWhitespace(heading.textContent || '').trim();
+      if (!title) {
+        return;
+      }
+      const items = parseSitemapList(list, origin);
+      if (items.length === 0) {
+        return;
+      }
+      groups.push({
+        title,
+        key: createGroupKey(title, index),
+        items
+      });
+    });
+    return groups;
+  }
+
+  function findNextListSibling(heading) {
+    let sibling = heading.nextElementSibling;
+    while (sibling) {
+      if (sibling.tagName === 'UL' || sibling.tagName === 'OL') {
+        return sibling;
+      }
+      sibling = sibling.nextElementSibling;
+    }
+    return null;
+  }
+
+  function parseSitemapList(list, origin) {
+    const items = [];
+    Array.from(list.children).forEach((child) => {
+      if (!(child instanceof HTMLElement) || child.tagName !== 'LI') {
+        return;
+      }
+      const anchor =
+        child.querySelector(':scope > a') ||
+        child.querySelector(':scope > div > a') ||
+        child.querySelector(':scope > span > a') ||
+        child.querySelector('a');
+      if (!anchor) {
+        return;
+      }
+      const title = normaliseWhitespace(anchor.textContent || '').trim();
+      if (!title) {
+        return;
+      }
+      const href = anchor.getAttribute('href') || '';
+      const absoluteUrl = safeBuildAbsoluteUrl(href, origin);
+      const path = extractPathFromUrl(absoluteUrl);
+      const nestedList = Array.from(child.children).find(
+        (node) => node instanceof HTMLElement && (node.tagName === 'UL' || node.tagName === 'OL')
+      );
+      const children = nestedList ? parseSitemapList(nestedList, origin) : [];
+      items.push({
+        title,
+        url: absoluteUrl,
+        path,
+        children
+      });
+    });
+    return items;
+  }
+
+  function safeBuildAbsoluteUrl(href, origin) {
+    try {
+      return new URL(href, origin).toString();
+    } catch (error) {
+      try {
+        return new URL(href, DEFAULT_BASE_URL).toString();
+      } catch (innerError) {
+        return href;
+      }
+    }
+  }
+
+  function extractPathFromUrl(urlValue) {
+    try {
+      const parsed = new URL(urlValue);
+      return `${parsed.pathname}${parsed.search || ''}`;
+    } catch (error) {
+      return urlValue;
+    }
+  }
+
+  function createGroupKey(title, index) {
+    const slug = title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '');
+    return `${slug || 'group'}-${index}`;
+  }
+
+  function renderStructurePanel() {
+    if (!elements.structureTree) {
+      return;
+    }
+
+    const summary = computeStructureSummary();
+
+    if (elements.structureSummaryLabel) {
+      let label;
+      if (state.structureLoading) {
+        label = 'Loading sitemap…';
+      } else if (state.structureError) {
+        label = 'Unable to load sitemap automatically. Paste URLs manually or retry once the helper server is running.';
+      } else if (state.siteStructure.length === 0) {
+        label = 'No sitemap data loaded yet. Click “Refresh sitemap” to fetch the latest structure.';
+      } else {
+        label = `${summary.selected} of ${summary.total} sections selected`;
+      }
+      elements.structureSummaryLabel.textContent = label;
+    }
+
+    if (elements.structureChips) {
+      if (state.structureLoading || state.structureError || summary.selectedList.length === 0) {
+        elements.structureChips.innerHTML = '';
+      } else {
+        elements.structureChips.innerHTML = summary.selectedList
+          .slice(0, 8)
+          .map(
+            (item) =>
+              `<span class="structure-chip" title="${escapeHtml(item.path)}">${escapeHtml(item.title)}</span>`
+          )
+          .join('');
+      }
+    }
+
+    if (elements.structureStatus) {
+      let statusMessage = '';
+      if (state.structureLoading) {
+        statusMessage = 'Loading sitemap…';
+      } else if (state.structureError) {
+        statusMessage = state.structureError;
+      }
+      elements.structureStatus.textContent = statusMessage;
+      elements.structureStatus.hidden = statusMessage.length === 0;
+    }
+
+    if (state.structureLoading) {
+      elements.structureTree.innerHTML =
+        '<div class="structure-skeleton"></div><div class="structure-skeleton"></div><div class="structure-skeleton"></div>';
+      elements.structureTree.setAttribute('aria-busy', 'true');
+      updateStructureActionState(summary);
+      return;
+    }
+
+    elements.structureTree.removeAttribute('aria-busy');
+
+    if (state.structureError || state.siteStructure.length === 0) {
+      elements.structureTree.innerHTML = '';
+      updateStructureActionState(summary);
+      return;
+    }
+
+    let total = 0;
+    let selected = 0;
+    const fragments = state.siteStructure.map((group) => {
+      const rendered = renderStructureGroup(group);
+      total += rendered.total;
+      selected += rendered.selected;
+      return rendered.html;
+    });
+
+    elements.structureTree.innerHTML = fragments.join('');
+    updateStructureActionState({ total, selected, selectedList: summary.selectedList });
+    setIndeterminateFlags();
+  }
+
+  function renderStructureGroup(group) {
+    let total = 0;
+    let selected = 0;
+    const items = group.items
+      .map((node) => {
+        const rendered = renderStructureNode(node);
+        total += rendered.total;
+        selected += rendered.selected;
+        return rendered.html;
+      })
+      .join('');
+    const isOpen = state.structureOpenGroups.has(group.key);
+    const html = `
+      <details class="structure-group" data-group="${escapeHtml(group.key)}" ${isOpen ? 'open' : ''}>
+        <summary>
+          <span>${escapeHtml(group.title)}</span>
+          <span class="structure-count">${selected} / ${total} selected</span>
+        </summary>
+        <div class="structure-group-body">
+          <div class="structure-group-actions">
+            <button type="button" class="chip-button" data-action="group-select-all" data-group="${escapeHtml(
+              group.key
+            )}" ${selected === total ? 'disabled' : ''}>Select group</button>
+            <button type="button" class="chip-button" data-action="group-clear" data-group="${escapeHtml(
+              group.key
+            )}" ${selected === 0 ? 'disabled' : ''}>Clear group</button>
+          </div>
+          <ul class="structure-list">
+            ${items}
+          </ul>
+        </div>
+      </details>
+    `;
+    return { html, total, selected };
+  }
+
+  function renderStructureNode(node) {
+    let total = 1;
+    const isSelected = state.selectedStructureUrls.has(node.url);
+    let selected = isSelected ? 1 : 0;
+    const childFragments = [];
+
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      node.children.forEach((child) => {
+        const renderedChild = renderStructureNode(child);
+        total += renderedChild.total;
+        selected += renderedChild.selected;
+        childFragments.push(renderedChild.html);
+      });
+    }
+
+    const hasChildren = childFragments.length > 0;
+    const indeterminate = !isSelected && selected > 0;
+    const metaParts = [];
+    if (hasChildren) {
+      metaParts.push(`${node.children.length} subpage${node.children.length === 1 ? '' : 's'}`);
+    }
+    if (node.path) {
+      metaParts.push(node.path);
+    }
+    const meta = metaParts.length ? `<div class="structure-meta">${escapeHtml(metaParts.join(' • '))}</div>` : '';
+    const childrenHtml = hasChildren ? `<div class="structure-children">${childFragments.join('')}</div>` : '';
+
+    const html = `
+      <li class="structure-node" data-url="${escapeHtml(node.url)}">
+        <label>
+          <input type="checkbox" data-url="${escapeHtml(node.url)}" ${isSelected ? 'checked' : ''} ${
+      indeterminate ? 'data-indeterminate="true"' : ''
+    } aria-label="${escapeHtml(node.title)}">
+          <span>${escapeHtml(node.title)}</span>
+        </label>
+        ${meta}
+        ${childrenHtml}
+      </li>
+    `;
+    return { html, total, selected };
+  }
+
+  function setIndeterminateFlags() {
+    if (!elements.structureTree) {
+      return;
+    }
+    const apply = () => {
+      elements.structureTree.querySelectorAll('input[data-indeterminate="true"]').forEach((input) => {
+        input.indeterminate = true;
+      });
+    };
+    if (typeof queueMicrotask === 'function') {
+      queueMicrotask(apply);
+    } else {
+      setTimeout(apply, 0);
+    }
+  }
+
+  function computeStructureSummary() {
+    let total = 0;
+    let selected = 0;
+    const collector = [];
+    state.siteStructure.forEach((group) => {
+      group.items.forEach((node) => {
+        const stats = gatherNodeStats(node, collector);
+        total += stats.total;
+        selected += stats.selected;
+      });
+    });
+    return { total, selected, selectedList: collector };
+  }
+
+  function gatherNodeStats(node, collector) {
+    let total = 1;
+    const isSelected = state.selectedStructureUrls.has(node.url);
+    let selected = isSelected ? 1 : 0;
+    if (isSelected && collector.length < 16) {
+      collector.push({ title: node.title, path: node.path || node.url });
+    }
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      node.children.forEach((child) => {
+        const childStats = gatherNodeStats(child, collector);
+        total += childStats.total;
+        selected += childStats.selected;
+      });
+    }
+    return { total, selected };
+  }
+
+  function updateStructureActionState(summary) {
+    if (!elements.structureActions) {
+      return;
+    }
+    const counts = summary || computeStructureSummary();
+    const total = counts.total;
+    const selected = counts.selected;
+    const hasStructure = state.siteStructure.length > 0;
+
+    elements.structureActions.querySelectorAll('button[data-action]').forEach((button) => {
+      const action = button.dataset.action;
+      if (action === 'refresh-structure') {
+        button.disabled = state.structureLoading;
+      } else if (action === 'select-all') {
+        button.disabled = state.structureLoading || !hasStructure || total === 0 || selected >= total;
+      } else if (action === 'clear-selection') {
+        button.disabled = state.structureLoading || selected === 0;
+      } else if (action === 'expand-all' || action === 'collapse-all') {
+        button.disabled = state.structureLoading || !hasStructure;
+      }
+    });
+  }
+
+  function handleStructureAction(event) {
+    const button = event.target.closest('button[data-action]');
+    if (!button) {
+      return;
+    }
+    const action = button.dataset.action;
+    if (!action) {
+      return;
+    }
+    event.preventDefault();
+    switch (action) {
+      case 'refresh-structure':
+        loadSiteStructure({ force: true });
+        break;
+      case 'select-all':
+        selectAllStructureNodes();
+        break;
+      case 'clear-selection':
+        clearAllStructureSelections();
+        break;
+      case 'expand-all':
+        expandAllStructureGroups();
+        break;
+      case 'collapse-all':
+        collapseAllStructureGroups();
+        break;
+      default:
+        break;
+    }
+  }
+
+  function handleStructureTreeChange(event) {
+    const input = event.target;
+    if (!(input instanceof HTMLInputElement) || !input.matches('input[type="checkbox"][data-url]')) {
+      return;
+    }
+    const url = input.dataset.url;
+    const node = findNodeByUrl(url);
+    const affectedUrls = node ? collectNodeUrls(node, []) : [url];
+    if (input.checked) {
+      affectedUrls.forEach((value) => state.selectedStructureUrls.add(value));
+    } else {
+      affectedUrls.forEach((value) => state.selectedStructureUrls.delete(value));
+    }
+    renderStructurePanel();
+    if (node) {
+      log(`${input.checked ? 'Selected' : 'Cleared'} “${node.title}” from the sitemap panel.`, 'info');
+    }
+  }
+
+  function handleStructureTreeClick(event) {
+    const button = event.target.closest('button[data-action]');
+    if (!button) {
+      return;
+    }
+    const action = button.dataset.action;
+    if (action !== 'group-select-all' && action !== 'group-clear') {
+      return;
+    }
+    event.preventDefault();
+    const groupKey = button.dataset.group;
+    if (!groupKey) {
+      return;
+    }
+    if (action === 'group-select-all') {
+      selectStructureGroup(groupKey);
+    } else {
+      clearStructureGroup(groupKey);
+    }
+  }
+
+  function handleStructureGroupToggle(event) {
+    const details = event.target;
+    if (!(details instanceof HTMLDetailsElement) || !details.matches('.structure-group')) {
+      return;
+    }
+    const key = details.dataset.group;
+    if (!key) {
+      return;
+    }
+    if (details.open) {
+      state.structureOpenGroups.add(key);
+    } else {
+      state.structureOpenGroups.delete(key);
+    }
+  }
+
+  function selectAllStructureNodes() {
+    const urls = [];
+    state.siteStructure.forEach((group) => collectGroupUrls(group, urls));
+    if (urls.length === 0) {
+      return;
+    }
+    urls.forEach((url) => state.selectedStructureUrls.add(url));
+    renderStructurePanel();
+    log(`Selected ${urls.length} section${urls.length === 1 ? '' : 's'} from the sitemap.`, 'success');
+  }
+
+  function clearAllStructureSelections() {
+    if (state.selectedStructureUrls.size === 0) {
+      return;
+    }
+    state.selectedStructureUrls.clear();
+    renderStructurePanel();
+    log('Cleared all sitemap selections.', 'info');
+  }
+
+  function expandAllStructureGroups() {
+    state.structureOpenGroups = new Set(state.siteStructure.map((group) => group.key));
+    renderStructurePanel();
+  }
+
+  function collapseAllStructureGroups() {
+    state.structureOpenGroups = new Set();
+    renderStructurePanel();
+  }
+
+  function selectStructureGroup(key) {
+    const group = findStructureGroup(key);
+    if (!group) {
+      return;
+    }
+    const urls = collectGroupUrls(group, []);
+    if (urls.length === 0) {
+      return;
+    }
+    urls.forEach((url) => state.selectedStructureUrls.add(url));
+    renderStructurePanel();
+    log(`Selected ${urls.length} section${urls.length === 1 ? '' : 's'} from “${group.title}”.`, 'success');
+  }
+
+  function clearStructureGroup(key) {
+    const group = findStructureGroup(key);
+    if (!group) {
+      return;
+    }
+    const urls = collectGroupUrls(group, []);
+    urls.forEach((url) => state.selectedStructureUrls.delete(url));
+    renderStructurePanel();
+    log(`Cleared selections for “${group.title}”.`, 'info');
+  }
+
+  function findStructureGroup(key) {
+    return state.siteStructure.find((group) => group.key === key) || null;
+  }
+
+  function findNodeByUrl(url) {
+    for (const group of state.siteStructure) {
+      const match = findNodeInList(group.items, url);
+      if (match) {
+        return match;
+      }
+    }
+    return null;
+  }
+
+  function findNodeInList(nodes, url) {
+    if (!Array.isArray(nodes)) {
+      return null;
+    }
+    for (const node of nodes) {
+      if (node.url === url) {
+        return node;
+      }
+      const childMatch = findNodeInList(node.children, url);
+      if (childMatch) {
+        return childMatch;
+      }
+    }
+    return null;
+  }
+
+  function collectGroupUrls(group, accumulator = []) {
+    if (!group || !Array.isArray(group.items)) {
+      return accumulator;
+    }
+    group.items.forEach((node) => collectNodeUrls(node, accumulator));
+    return accumulator;
+  }
+
+  function collectNodeUrls(node, accumulator = []) {
+    if (!node) {
+      return accumulator;
+    }
+    const add = (value) => {
+      if (!value) {
+        return;
+      }
+      if (accumulator instanceof Set) {
+        accumulator.add(value);
+      } else if (Array.isArray(accumulator)) {
+        accumulator.push(value);
+      }
+    };
+    add(node.url);
+    if (Array.isArray(node.children) && node.children.length > 0) {
+      node.children.forEach((child) => collectNodeUrls(child, accumulator));
+    }
+    return accumulator;
   }
 
   function setMode(mode) {
@@ -127,24 +829,51 @@
       return;
     }
 
-    state.baseUrl = (elements.baseUrl.value || 'https://www.adxs.org').trim().replace(/\/$/, '');
-    const rawPaths = elements.paths.value
+    if (!ensureHttpContext()) {
+      return;
+    }
+
+    const baseInput = elements.baseUrl.value?.trim() || DEFAULT_BASE_URL;
+    state.baseUrl = baseInput.replace(/\/$/, '') || DEFAULT_BASE_URL;
+    state.language = deriveLanguageSegment(state.baseUrl);
+
+    const currentOrigin = extractOrigin(state.baseUrl);
+    if (state.structureOrigin !== currentOrigin || state.structureLanguage !== state.language) {
+      loadSiteStructure({ silent: true, force: true });
+    }
+
+    const manualPaths = (elements.paths.value || '')
       .split(/\n+/)
       .map((line) => line.trim())
       .filter((line) => line.length > 0);
 
-    if (rawPaths.length === 0) {
-      rawPaths.push('');
+    const sitemapSelections = Array.from(state.selectedStructureUrls);
+    const combined = [...sitemapSelections, ...manualPaths];
+
+    if (combined.length === 0) {
+      combined.push('');
     }
+
+    const uniquePaths = Array.from(new Set(combined));
 
     let queue;
     if (state.mode === 'single') {
-      queue = [buildUrl(rawPaths[0])];
-      if (rawPaths.length > 1) {
-        log('Single page mode only scrapes the first path provided. Additional entries were ignored.', 'warning');
+      queue = [buildUrl(uniquePaths[0])];
+      if (uniquePaths.length > 1) {
+        log('Single page mode only scrapes the first selected or entered path. Extra entries were skipped.', 'warning');
       }
     } else {
-      queue = rawPaths.map((path) => buildUrl(path));
+      queue = uniquePaths.map((path) => buildUrl(path));
+    }
+
+    if (sitemapSelections.length > 0) {
+      log(
+        `${sitemapSelections.length} sitemap selection${sitemapSelections.length === 1 ? '' : 's'} added to the queue.`,
+        'info'
+      );
+    }
+    if (manualPaths.length > 0) {
+      log(`${manualPaths.length} manual path${manualPaths.length === 1 ? '' : 's'} added to the queue.`, 'info');
     }
 
     state.queue = queue;
@@ -152,6 +881,8 @@
     state.processed = 0;
     state.results = [];
     state.logs = [];
+    state.documents = [];
+    state.selectedSections = new Map();
     state.isRunning = true;
     state.isPaused = false;
 
@@ -159,6 +890,9 @@
     elements.pauseBtn.textContent = 'Pause';
     elements.stopBtn.disabled = false;
     elements.startBtn.disabled = true;
+    if (elements.documentName) {
+      elements.documentName.value = '';
+    }
 
     updateStatus('active', 'Running');
     updateProgress();
@@ -167,6 +901,8 @@
     renderPreview();
     renderStats();
     renderValidation();
+    renderDocumentBuilder();
+    renderDocuments();
     log(`Session started in ${modeLabel(state.mode)} mode targeting ${state.total} page${state.total === 1 ? '' : 's'}.`);
     processQueue();
   }
@@ -208,6 +944,8 @@
     elements.pauseBtn.textContent = 'Pause';
     updateStatus('idle', 'Stopped');
     updateProgress();
+    renderDocumentBuilder();
+    renderDocuments();
     log('Session stopped by user.');
   }
 
@@ -234,6 +972,8 @@
       renderStats();
       updateExports();
       renderValidation();
+      renderDocumentBuilder();
+      renderDocuments();
       if (result.validation?.summary) {
         const { summary } = result.validation;
         const validationSeverity = summary.status === 'error' ? 'error' : summary.status === 'warning' ? 'warning' : 'success';
@@ -270,14 +1010,18 @@
     updateStatus('idle', 'Completed');
     updateProgress();
     renderLogs();
+    renderDocumentBuilder();
+    renderDocuments();
     log('Scraping session completed.');
   }
 
   async function scrapeUrl(url) {
-    const response = await fetch(url, {
+    const response = await fetch(buildProxyUrl(url), {
       method: 'GET',
-      mode: 'cors',
-      credentials: 'omit'
+      credentials: 'omit',
+      headers: {
+        Accept: 'text/html,application/xhtml+xml'
+      }
     });
 
     if (!response.ok) {
@@ -296,11 +1040,7 @@
     const footnotes = state.options.footnotes ? collectFootnotes(doc) : [];
     const validation = validatePage(inlineCitations, tooltips, footnotes, state.options);
 
-    const wordCount = main.textContent
-      .replace(/\s+/g, ' ')
-      .trim()
-      .split(' ')
-      .filter(Boolean).length;
+    const wordCount = countWords(main.textContent);
 
     return {
       url,
@@ -376,32 +1116,36 @@
   }
 
   function collectInlineCitations(root) {
-    const nodes = Array.from(
-      root.querySelectorAll('sup, a[rel="footnote"], a[href*="#cite"], a[href*="#footnote"], a[href*="#fn"], span.citation')
-    );
+    const doc = root.ownerDocument || document;
+    const selector =
+      'sup, a[rel="footnote"], a[role="doc-noteref"], a.footnote-ref, a[href*="#cite"], a[href*="#footnote"], a[href*="#fn"], span.citation';
+    const nodes = Array.from(root.querySelectorAll(selector));
 
     const citations = nodes
       .map((node, index) => {
-        const anchor = node.tagName === 'SUP' ? node.querySelector('a') || node : node;
-        const href = anchor.getAttribute('href') || '';
-        const text = anchor.textContent.trim();
+        const sup = node.closest('sup');
+        const anchor = resolveCitationAnchor(node);
+        const text = normaliseWhitespace(anchor?.textContent || node.textContent);
         if (!text) {
           return null;
         }
-        const tooltipId = (anchor.getAttribute('aria-describedby') || node.getAttribute('aria-describedby') || '').trim();
-        const tooltipText =
-          anchor.getAttribute('data-tooltip') ||
-          anchor.getAttribute('title') ||
-          node.getAttribute('data-tooltip') ||
-          node.getAttribute('title') ||
+        const href = anchor?.getAttribute('href') || node.getAttribute('href') || '';
+        const tooltipId =
+          anchor?.getAttribute('aria-describedby') ||
+          node.getAttribute('aria-describedby') ||
+          sup?.id ||
+          anchor?.id ||
+          node.id ||
           '';
+        const tooltipInfo = extractTooltipContent(doc, anchor, node, sup);
         return {
-          id: anchor.id || node.id || `citation-${index + 1}`,
+          id: anchor?.id || node.id || sup?.id || `citation-${index + 1}`,
           text,
           href,
-          tooltipId,
-          tooltipText: tooltipText.trim(),
-          context: node.closest('p, li')?.textContent?.trim().slice(0, 240) || ''
+          tooltipId: tooltipId.trim(),
+          tooltipText: tooltipInfo.text,
+          tooltipHtml: tooltipInfo.html,
+          context: normaliseWhitespace(node.closest('p, li')?.textContent || '').slice(0, 240)
         };
       })
       .filter(Boolean);
@@ -409,7 +1153,7 @@
     const unique = [];
     const seen = new Set();
     citations.forEach((item) => {
-      const key = `${item.text}|${item.href}`;
+      const key = `${item.text}|${item.href}|${item.tooltipHtml}`;
       if (!seen.has(key)) {
         seen.add(key);
         unique.push(item);
@@ -420,15 +1164,25 @@
   }
 
   function collectTooltips(root) {
-    const nodes = Array.from(root.querySelectorAll('[data-tooltip], [title], abbr[title], span.tooltip'));
+    const doc = root.ownerDocument || document;
+    const selector = '[data-tippy-content], [data-tooltip], [title], abbr[title], span.tooltip';
+    const nodes = Array.from(root.querySelectorAll(selector));
     return nodes
       .map((node, index) => {
-        const tooltip = node.getAttribute('data-tooltip') || node.getAttribute('title');
-        if (!tooltip) return null;
+        const sup = node.closest('sup');
+        const tooltipInfo = extractTooltipContent(doc, node, sup);
+        if (!tooltipInfo.text && !tooltipInfo.html) return null;
+        const referenceId =
+          node.getAttribute('aria-describedby') ||
+          node.getAttribute('data-tooltip-id') ||
+          sup?.id ||
+          '';
         return {
-          id: node.id || `tooltip-${index + 1}`,
-          text: tooltip.trim(),
-          context: node.textContent.trim()
+          id: node.id || sup?.id || `tooltip-${index + 1}`,
+          referenceId: referenceId.trim(),
+          text: tooltipInfo.text,
+          html: tooltipInfo.html,
+          context: normaliseWhitespace(node.textContent).slice(0, 240)
         };
       })
       .filter(Boolean);
@@ -459,7 +1213,7 @@
       seen.add(id);
       unique.push({
         id,
-        text: node.textContent.trim(),
+        text: normaliseWhitespace(node.textContent),
         html: node.innerHTML.trim()
       });
     });
@@ -537,7 +1291,7 @@
     const tooltipTextMap = new Map();
     if (captureTooltips) {
       tooltips.forEach((tooltip) => {
-        collectKeys([tooltip.id]).forEach((key) => {
+        collectKeys([tooltip.id, tooltip.referenceId]).forEach((key) => {
           if (!tooltipMap.has(key)) {
             tooltipMap.set(key, tooltip);
           }
@@ -578,7 +1332,7 @@
         for (const key of tooltipKeys) {
           if (tooltipMap.has(key)) {
             tooltip = tooltipMap.get(key);
-            collectKeys([tooltip.id]).forEach((variant) => referencedTooltipIds.add(variant));
+            collectKeys([tooltip.id, tooltip.referenceId]).forEach((variant) => referencedTooltipIds.add(variant));
             if (tooltip.text) {
               referencedTooltipTexts.add(tooltip.text.trim().toLowerCase());
             }
@@ -591,7 +1345,7 @@
           if (tooltipTextMap.has(textKey)) {
             tooltip = tooltipTextMap.get(textKey);
             if (tooltip.id) {
-              collectKeys([tooltip.id]).forEach((variant) => referencedTooltipIds.add(variant));
+              collectKeys([tooltip.id, tooltip.referenceId]).forEach((variant) => referencedTooltipIds.add(variant));
             }
             referencedTooltipTexts.add(textKey);
           }
@@ -650,7 +1404,9 @@
           footnoteId: footnote?.id || '',
           footnoteTarget,
           tooltipId: tooltip?.id || citation.tooltipId || '',
+          tooltipReferenceId: tooltip?.referenceId || citation.tooltipId || '',
           tooltipText: citation.tooltipText || tooltip?.text || '',
+          tooltipHtml: citation.tooltipHtml || tooltip?.html || '',
           href: citation.href,
           context: citation.context || ''
         }
@@ -683,13 +1439,16 @@
           idKeys.some((key) => referencedTooltipIds.has(key)) ||
           (textKey && referencedTooltipTexts.has(textKey));
         if (!hasReference) {
+          const label = tooltip.id || tooltip.referenceId || tooltip.text.slice(0, 40) || `#${tooltips.indexOf(tooltip) + 1}`;
           record({
             severity: 'warning',
             scope: 'tooltip',
-            message: `Tooltip ${tooltip.id || tooltip.text.slice(0, 40)} is not associated with any citation.`,
+            message: `Tooltip ${label} is not associated with any citation.`,
             details: {
               tooltipId: tooltip.id,
-              tooltipText: tooltip.text
+              referenceId: tooltip.referenceId || '',
+              tooltipText: tooltip.text,
+              tooltipHtml: tooltip.html || ''
             }
           });
         }
@@ -944,7 +1703,17 @@
       .map((item) => {
         const detailLines = [];
         if (item.details) {
-          const { citationText, citationId, footnoteId, footnoteTarget, tooltipId, tooltipText, href } = item.details;
+          const {
+            citationText,
+            citationId,
+            footnoteId,
+            footnoteTarget,
+            tooltipId,
+            tooltipText,
+            tooltipReferenceId,
+            tooltipHtml,
+            href
+          } = item.details;
           if (citationText) {
             detailLines.push(`Citation text: ${citationText}`);
           }
@@ -961,6 +1730,13 @@
             detailLines.push(`Tooltip ref: ${tooltipId}`);
           } else if (tooltipText && item.scope === 'citation') {
             detailLines.push(`Tooltip text: ${tooltipText}`);
+          }
+          if (tooltipReferenceId && tooltipReferenceId !== tooltipId) {
+            detailLines.push(`Tooltip reference id: ${tooltipReferenceId}`);
+          }
+          if (tooltipHtml && item.scope === 'tooltip') {
+            const clipped = tooltipHtml.length > 120 ? `${tooltipHtml.slice(0, 120)}…` : tooltipHtml;
+            detailLines.push(`Tooltip HTML: ${clipped}`);
           }
           if (href) {
             detailLines.push(`Href: ${href}`);
@@ -999,6 +1775,471 @@
         `;
       })
       .join('');
+  }
+
+  function renderDocumentBuilder() {
+    if (!elements.documentBuilder || !elements.documentsEmpty || !elements.documentActions) {
+      return;
+    }
+
+    const hasResults = state.results.length > 0;
+    elements.documentsEmpty.hidden = hasResults;
+    elements.documentBuilder.hidden = !hasResults;
+    elements.documentActions.hidden = !hasResults;
+
+    if (!hasResults) {
+      if (elements.documentList) {
+        elements.documentList.hidden = true;
+        elements.documentList.innerHTML = '';
+      }
+      return;
+    }
+
+    const markup = state.results
+      .map((result, index) => {
+        const selectedIds = state.selectedSections.get(index) || new Set();
+        const sectionMarkup = result.sections
+          .map(
+            (section) => `
+              <div class="doc-section">
+                <label>
+                  <input type="checkbox" data-page-index="${index}" data-section-id="${escapeHtml(section.id)}" ${
+              selectedIds.has(section.id) ? 'checked' : ''
+            }>
+                  <span>${escapeHtml(section.heading)}</span>
+                </label>
+              </div>
+            `
+          )
+          .join('');
+        const sectionLabel = `${result.stats.sections} section${result.stats.sections === 1 ? '' : 's'}`;
+        const selectedLabel = `${selectedIds.size} selected`;
+        const openAttr = selectedIds.size > 0 ? ' open' : '';
+        return `
+          <details class="doc-source" data-page-index="${index}"${openAttr}>
+            <summary data-page-index="${index}">
+              <span>${escapeHtml(result.title)}</span>
+              <span class="doc-meta">
+                <span data-role="total">${sectionLabel}</span>
+                <span data-role="selected" data-page-index="${index}">${selectedLabel}</span>
+              </span>
+            </summary>
+            <div class="doc-section-list">
+              ${sectionMarkup || '<p class="document-empty">No sections detected for this page.</p>'}
+            </div>
+          </details>
+        `;
+      })
+      .join('');
+
+    elements.documentBuilder.innerHTML = markup;
+  }
+
+  function handleDocumentSelectionChange(event) {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') {
+      return;
+    }
+    const pageIndex = Number(target.dataset.pageIndex);
+    const sectionId = target.dataset.sectionId;
+    if (!Number.isInteger(pageIndex) || !sectionId) {
+      return;
+    }
+
+    let selection = state.selectedSections.get(pageIndex);
+    if (!selection) {
+      selection = new Set();
+      state.selectedSections.set(pageIndex, selection);
+    }
+
+    if (target.checked) {
+      selection.add(sectionId);
+    } else {
+      selection.delete(sectionId);
+      if (selection.size === 0) {
+        state.selectedSections.delete(pageIndex);
+      }
+    }
+
+    updateDocumentSelectionMeta(pageIndex);
+  }
+
+  function updateDocumentSelectionMeta(pageIndex) {
+    if (!elements.documentBuilder) return;
+    const meta = elements.documentBuilder.querySelector(
+      `summary [data-role="selected"][data-page-index="${pageIndex}"]`
+    );
+    const selection = state.selectedSections.get(pageIndex);
+    const count = selection ? selection.size : 0;
+    if (meta) {
+      meta.textContent = `${count} selected`;
+    }
+  }
+
+  function clearSelectedSections() {
+    if (state.selectedSections.size === 0) {
+      log('No sections are currently selected.', 'info');
+      return;
+    }
+    state.selectedSections.clear();
+    renderDocumentBuilder();
+    renderDocuments();
+    log('Cleared the current section selection.', 'info');
+  }
+
+  function collectSelectedSections() {
+    const collected = [];
+    state.results.forEach((result, pageIndex) => {
+      const selection = state.selectedSections.get(pageIndex);
+      if (!selection || selection.size === 0) {
+        return;
+      }
+      result.sections.forEach((section) => {
+        if (!selection.has(section.id)) return;
+        collected.push({
+          pageIndex,
+          pageUrl: result.url,
+          pageTitle: result.title,
+          sectionId: section.id,
+          heading: section.heading,
+          text: section.text,
+          html: section.html,
+          wordCount: countWords(section.text)
+        });
+      });
+    });
+    return collected;
+  }
+
+  function createDocumentFromSelection() {
+    const sections = collectSelectedSections();
+    if (sections.length === 0) {
+      log('Select at least one section before creating a document.', 'warning');
+      return;
+    }
+
+    const nameInput = elements.documentName?.value || '';
+    const name = normaliseWhitespace(nameInput) || `Document ${state.documents.length + 1}`;
+    const grouped = groupSectionsByPage(sections);
+    const wordCount = sections.reduce((total, section) => total + section.wordCount, 0);
+    const documentRecord = {
+      id: `doc-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
+      name,
+      createdAt: new Date().toISOString(),
+      sections,
+      stats: {
+        sections: sections.length,
+        pages: grouped.length,
+        words: wordCount
+      }
+    };
+
+    state.documents.push(documentRecord);
+    if (elements.documentName) {
+      elements.documentName.value = '';
+    }
+    log(
+      `Created document "${name}" with ${documentRecord.stats.sections} section${
+        documentRecord.stats.sections === 1 ? '' : 's'
+      } from ${documentRecord.stats.pages} page${documentRecord.stats.pages === 1 ? '' : 's'}.`,
+      'success'
+    );
+    renderDocuments();
+  }
+
+  function handleDocumentListClick(event) {
+    const button = event.target.closest('button[data-doc-id]');
+    if (!button) return;
+    const docId = button.dataset.docId;
+    if (!docId) return;
+
+    if (button.dataset.action === 'remove') {
+      removeDocument(docId);
+      return;
+    }
+
+    const format = button.dataset.format;
+    if (format) {
+      exportDocument(docId, format);
+    }
+  }
+
+  function removeDocument(docId) {
+    const index = state.documents.findIndex((doc) => doc.id === docId);
+    if (index === -1) {
+      log('Unable to find the requested document.', 'error');
+      return;
+    }
+    const [removed] = state.documents.splice(index, 1);
+    log(`Removed document "${removed.name}".`, 'info');
+    renderDocuments();
+  }
+
+  function renderDocuments() {
+    if (!elements.documentList) return;
+
+    if (state.results.length === 0) {
+      elements.documentList.hidden = true;
+      elements.documentList.innerHTML = '';
+      return;
+    }
+
+    if (state.documents.length === 0) {
+      elements.documentList.hidden = false;
+      elements.documentList.innerHTML =
+        '<p class="document-empty">No custom documents yet. Select sections above and create your first document.</p>';
+      return;
+    }
+
+    const cards = state.documents
+      .map((doc) => {
+        const createdDate = new Date(doc.createdAt);
+        const preview = doc.sections
+          .slice(0, 4)
+          .map((section) => `<li>${escapeHtml(section.heading)}<span>${escapeHtml(section.pageTitle)}</span></li>`)
+          .join('');
+        return `
+          <article class="document-card" data-doc-id="${doc.id}">
+            <header>
+              <h3>${escapeHtml(doc.name)}</h3>
+              <div class="meta">
+                <span>${doc.stats.sections} section${doc.stats.sections === 1 ? '' : 's'}</span>
+                <span>${doc.stats.pages} page${doc.stats.pages === 1 ? '' : 's'}</span>
+                <span>${doc.stats.words.toLocaleString()} words</span>
+              </div>
+            </header>
+            <div class="meta">
+              <span>Created ${createdDate.toLocaleString()}</span>
+            </div>
+            <ul class="doc-section-preview">
+              ${preview}
+            </ul>
+            <footer>
+              <button type="button" class="control" data-doc-id="${doc.id}" data-format="markdown">Markdown</button>
+              <button type="button" class="control" data-doc-id="${doc.id}" data-format="html">HTML</button>
+              <button type="button" class="control" data-doc-id="${doc.id}" data-format="json">JSON</button>
+              <button type="button" class="control" data-doc-id="${doc.id}" data-action="remove">Remove</button>
+            </footer>
+          </article>
+        `;
+      })
+      .join('');
+
+    elements.documentList.hidden = false;
+    elements.documentList.innerHTML = cards;
+  }
+
+  function exportDocument(docId, format) {
+    const doc = state.documents.find((item) => item.id === docId);
+    if (!doc) {
+      log('Unable to find the requested document.', 'error');
+      return;
+    }
+
+    const slug = slugify(doc.name, 'adxs-document');
+    switch (format) {
+      case 'markdown':
+        downloadFile(`${slug}.md`, convertDocumentToMarkdown(doc), 'text/markdown');
+        break;
+      case 'html':
+        downloadFile(`${slug}.html`, convertDocumentToHtml(doc), 'text/html');
+        break;
+      case 'json':
+        downloadFile(`${slug}.json`, JSON.stringify(doc, null, 2), 'application/json');
+        break;
+      default:
+        log(`Unsupported document export format: ${format}`, 'error');
+    }
+  }
+
+  function convertDocumentToMarkdown(doc) {
+    const lines = [
+      `# ${doc.name}`,
+      '',
+      `Generated: ${doc.createdAt}`,
+      `Sections: ${doc.stats.sections}`,
+      `Pages: ${doc.stats.pages}`,
+      `Words: ${doc.stats.words}`,
+      ''
+    ];
+
+    const grouped = groupSectionsByPage(doc.sections);
+    grouped.forEach((group) => {
+      lines.push(`## ${group.pageTitle}`);
+      lines.push(group.pageUrl);
+      lines.push('');
+      group.sections.forEach((section) => {
+        lines.push(`### ${section.heading}`);
+        lines.push(section.text);
+        lines.push('');
+      });
+    });
+
+    return lines.join('\n');
+  }
+
+  function convertDocumentToHtml(doc) {
+    const grouped = groupSectionsByPage(doc.sections);
+    const body = grouped
+      .map((group) => {
+        const sectionsHtml = group.sections
+          .map(
+            (section) => `
+            <section id="${escapeHtml(section.sectionId)}">
+              <h3>${escapeHtml(section.heading)}</h3>
+              <div>${section.html}</div>
+            </section>`
+          )
+          .join('\n');
+
+        return `
+        <article class="page-result">
+          <header>
+            <h2>${escapeHtml(group.pageTitle)}</h2>
+            <p><a href="${group.pageUrl}">${group.pageUrl}</a></p>
+          </header>
+          ${sectionsHtml}
+        </article>`;
+      })
+      .join('\n');
+
+    const wordsFormatted = doc.stats.words.toLocaleString();
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>${escapeHtml(doc.name)} — ADXS export</title>
+<style>
+body { font-family: Inter, system-ui, -apple-system, "Segoe UI", sans-serif; margin: 2rem auto; max-width: 960px; line-height: 1.6; color: #0f172a; }
+h1, h2, h3 { font-weight: 600; }
+.page-result { margin-bottom: 3rem; border-bottom: 1px solid #cbd5f5; padding-bottom: 2rem; }
+.page-result header h2 { margin-bottom: 0.25rem; }
+.page-result header p { margin-top: 0; }
+section { margin-bottom: 1.5rem; }
+section h3 { margin-top: 0; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(doc.name)}</h1>
+<p>Generated: ${doc.createdAt}</p>
+<p>Sections: ${doc.stats.sections} • Pages: ${doc.stats.pages} • Words: ${wordsFormatted}</p>
+${body}
+</body>
+</html>`;
+  }
+
+  function groupSectionsByPage(sections) {
+    const groups = [];
+    sections.forEach((section) => {
+      let group = groups.find((entry) => entry.pageUrl === section.pageUrl);
+      if (!group) {
+        group = { pageUrl: section.pageUrl, pageTitle: section.pageTitle, sections: [] };
+        groups.push(group);
+      }
+      group.sections.push(section);
+    });
+    return groups;
+  }
+
+  function slugify(value, fallback = 'document') {
+    const base = normaliseWhitespace(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    const slug = base || fallback;
+    return slug.slice(0, 80);
+  }
+
+  function countWords(text) {
+    const normalised = normaliseWhitespace(text);
+    if (!normalised) return 0;
+    return normalised.split(' ').filter(Boolean).length;
+  }
+
+  function normaliseWhitespace(value) {
+    return (value ?? '').replace(/\s+/g, ' ').trim();
+  }
+
+  function extractTooltipContent(doc, ...nodes) {
+    let html = '';
+    for (const node of nodes) {
+      if (!node || typeof node.getAttribute !== 'function') continue;
+      const candidate =
+        node.getAttribute('data-tippy-content') ||
+        node.getAttribute('data-tooltip') ||
+        node.getAttribute('title') ||
+        node.getAttribute('data-original-title');
+      if (candidate) {
+        html = candidate.trim();
+        break;
+      }
+    }
+
+    if (!html) {
+      return { text: '', html: '' };
+    }
+
+    const container = doc.createElement('div');
+    container.innerHTML = html;
+    const text = normaliseWhitespace(container.textContent);
+    const sanitisedHtml = container.innerHTML.trim() || html;
+    return { text, html: sanitisedHtml };
+  }
+
+  function resolveCitationAnchor(node) {
+    if (!node) return null;
+    if (node.tagName === 'A') {
+      return node;
+    }
+    const directAnchor = node.querySelector('a.footnote-ref, a[role="doc-noteref"], a[href], a');
+    if (directAnchor) {
+      return directAnchor;
+    }
+    if (node.tagName === 'SUP' || node.tagName === 'SPAN') {
+      const spanWithTooltip = node.querySelector('span[data-tippy-content], span[data-tooltip], span');
+      if (spanWithTooltip) {
+        const nestedAnchor = spanWithTooltip.querySelector('a');
+        return nestedAnchor || spanWithTooltip;
+      }
+    }
+    return node;
+  }
+
+  function ensureHttpContext() {
+    const isHttp = window.location.protocol === 'http:' || window.location.protocol === 'https:';
+    if (!isHttp) {
+      updateProxyWarning(true);
+      log('Start the helper server with npm run dev and open http://localhost:3000 before scraping.', 'error');
+      return false;
+    }
+    updateProxyWarning(false);
+    return true;
+  }
+
+  function updateProxyWarning(forceShow = false) {
+    if (!elements.proxyWarning) return;
+    const isHttp = window.location.protocol === 'http:' || window.location.protocol === 'https:';
+    const shouldShow = forceShow || !isHttp;
+    elements.proxyWarning.hidden = !shouldShow;
+  }
+
+  function buildProxyUrl(targetUrl) {
+    if (!targetUrl) {
+      throw new Error('Missing target URL for proxy request.');
+    }
+
+    const parsed = new URL(targetUrl);
+    if (!/^https?:$/.test(parsed.protocol)) {
+      throw new Error(`Unsupported protocol for ${targetUrl}`);
+    }
+
+    const origin = window.location.origin;
+    if (!origin || origin === 'null') {
+      throw new Error('Local helper server unavailable. Run npm run dev and reload from http://localhost:3000.');
+    }
+
+    const endpoint = new URL('/api/fetch', origin);
+    endpoint.searchParams.set('url', targetUrl);
+    endpoint.searchParams.set('_ts', Date.now().toString());
+    return endpoint.toString();
   }
 
   function renderLogs() {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const ROOT = path.resolve(__dirname || '.');
+
+const DEFAULT_ALLOWED = ['www.adxs.org', 'adxs.org'];
+const allowedHosts = new Set(
+  (process.env.ALLOWED_HOSTS || DEFAULT_ALLOWED.join(','))
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+);
+
+app.use((req, res, next) => {
+  res.setHeader('X-Proxy-By', 'adxs-local-helper');
+  next();
+});
+
+app.get('/api/fetch', async (req, res) => {
+  const target = req.query.url;
+  if (!target) {
+    return res.status(400).json({ error: 'Missing url query parameter.' });
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(target);
+  } catch (error) {
+    return res.status(400).json({ error: 'Invalid URL provided.', details: error.message });
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return res.status(400).json({ error: 'Only HTTP(S) protocols are supported.' });
+  }
+
+  if (allowedHosts.size > 0 && !allowedHosts.has(parsed.hostname)) {
+    return res.status(403).json({ error: 'Host not permitted by proxy.', host: parsed.hostname });
+  }
+
+  try {
+    console.log(`[proxy] ${parsed.toString()}`);
+    const response = await fetch(parsed.toString(), {
+      headers: {
+        'User-Agent': 'adxs-scraper/1.0 (+local proxy)'
+      }
+    });
+
+    const text = await response.text();
+    res.status(response.status);
+    res.setHeader('Cache-Control', 'no-store');
+    const contentType = response.headers.get('content-type');
+    if (contentType) {
+      res.setHeader('Content-Type', contentType);
+    } else {
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    }
+    res.send(text);
+  } catch (error) {
+    console.error('[proxy] error', error);
+    res.status(502).json({ error: 'Proxy request failed.', details: error.message });
+  }
+});
+
+app.use(express.static(ROOT));
+
+app.listen(PORT, () => {
+  console.log(`ADXS helper server running on http://localhost:${PORT}`);
+  console.log(`Allowed hosts: ${Array.from(allowedHosts).join(', ') || 'none'}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,228 @@ a:hover {
   backdrop-filter: blur(12px);
 }
 
+.results {
+  grid-row: span 2;
+}
+
+.structure {
+  align-self: start;
+}
+
+.structure-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.structure-intro p {
+  color: rgba(226, 232, 240, 0.7);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.structure-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip-button {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(30, 41, 59, 0.65);
+  color: inherit;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.chip-button:hover:not(:disabled) {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(56, 189, 248, 0.18);
+  transform: translateY(-1px);
+}
+
+.chip-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.structure-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.structure-summary p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.structure-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.structure-chip {
+  padding: 0.3rem 0.7rem;
+  border-radius: 0.75rem;
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  font-size: 0.75rem;
+  color: rgba(226, 232, 240, 0.95);
+  white-space: nowrap;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.structure-status {
+  font-size: 0.8rem;
+  color: rgba(248, 250, 252, 0.75);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  padding: 0.6rem 0.75rem;
+}
+
+.structure-tree {
+  border-radius: 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  padding: 1rem 1.2rem;
+  max-height: 32rem;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.structure-tree[aria-busy="true"] {
+  opacity: 0.6;
+}
+
+.structure-group {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.35);
+  overflow: hidden;
+}
+
+.structure-group summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.structure-group summary::-webkit-details-marker {
+  display: none;
+}
+
+.structure-group summary::after {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid rgba(148, 163, 184, 0.6);
+  border-bottom: 2px solid rgba(148, 163, 184, 0.6);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.structure-group[open] summary::after {
+  transform: rotate(-135deg);
+}
+
+.structure-count {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgba(148, 163, 184, 0.85);
+  white-space: nowrap;
+}
+
+.structure-group-body {
+  padding: 0.5rem 1rem 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.structure-group-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.structure-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.structure-node {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.45);
+  padding: 0.65rem 0.8rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.structure-node label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.structure-node label input[type="checkbox"] {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--accent);
+  margin-top: 0.2rem;
+}
+
+.structure-meta {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.structure-children {
+  border-left: 1px solid rgba(148, 163, 184, 0.2);
+  margin-left: 1.2rem;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.structure-skeleton {
+  border-radius: 0.85rem;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.08), rgba(148, 163, 184, 0.16), rgba(148, 163, 184, 0.08));
+  height: 2.5rem;
+  animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    background-position: -120%;
+  }
+  100% {
+    background-position: 120%;
+  }
+}
+
 .panel-header {
   margin-bottom: 1.5rem;
 }
@@ -131,7 +353,30 @@ a:hover {
   font-size: 0.75rem;
 }
 
+.inline-warning {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(56, 189, 248, 0.12);
+  padding: 0.75rem 1rem;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.85rem;
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.inline-warning code {
+  background: rgba(15, 23, 42, 0.7);
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  font-family: "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+  font-size: 0.75rem;
+  color: rgba(224, 242, 254, 0.95);
+}
+
 input[type="url"],
+input[type="text"],
 textarea {
   width: 100%;
   padding: 0.75rem 1rem;
@@ -144,6 +389,7 @@ textarea {
 }
 
 input[type="url"]:focus,
+input[type="text"]:focus,
 textarea:focus {
   outline: none;
   border-color: rgba(56, 189, 248, 0.8);
@@ -352,6 +598,168 @@ textarea {
   font-size: 0.9rem;
   line-height: 1.5;
   color: rgba(226, 232, 240, 0.9);
+}
+
+.documents-intro {
+  color: rgba(226, 232, 240, 0.75);
+  margin-bottom: 1rem;
+  line-height: 1.5;
+}
+
+.document-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.doc-source {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  padding: 1rem 1.25rem;
+}
+
+.doc-source summary {
+  cursor: pointer;
+  font-weight: 600;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.doc-source summary::-webkit-details-marker {
+  display: none;
+}
+
+.doc-source summary::after {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid rgba(148, 163, 184, 0.6);
+  border-bottom: 2px solid rgba(148, 163, 184, 0.6);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.doc-source[open] summary::after {
+  transform: rotate(-135deg);
+}
+
+.doc-meta {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.doc-section-list {
+  margin-top: 0.85rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.doc-section label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.65rem 0.75rem;
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.doc-section label:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.doc-section input[type="checkbox"] {
+  margin-top: 0.2rem;
+}
+
+.document-actions {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto auto;
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1.5rem;
+}
+
+.document-actions .control {
+  height: 100%;
+}
+
+.document-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.document-card {
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.document-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.document-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.document-card .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.document-card footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.document-card .control {
+  padding: 0.5rem 0.9rem;
+  font-size: 0.8rem;
+  border-radius: 0.65rem;
+}
+
+.document-empty {
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.85rem;
+}
+
+.doc-section-preview {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.doc-section-preview li span {
+  display: block;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.75rem;
 }
 
 .stats-grid {
@@ -586,6 +994,11 @@ textarea {
 
   .results {
     order: -1;
+    grid-row: auto;
+  }
+
+  .structure {
+    order: 1;
   }
 }
 
@@ -606,5 +1019,26 @@ textarea {
 
   .control {
     width: 100%;
+  }
+
+  .document-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .document-actions .control {
+    width: 100%;
+  }
+
+  .structure-toolbar {
+    gap: 0.35rem;
+  }
+
+  .chip-button {
+    flex: 1 1 calc(50% - 0.35rem);
+    text-align: center;
+  }
+
+  .structure-tree {
+    max-height: 22rem;
   }
 }


### PR DESCRIPTION
## Summary
- add a sitemap-driven section picker with selection summary, group controls, and queue integration
- adjust layout and styling to keep the results panel spanning rows and ensure the new structure pane works on mobile
- extend the scraper controller with sitemap parsing, selection management, and automatic refreshes, plus update the README with desktop and Android walkthroughs

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68c9efc908848329bfa5c68f96550ea6