### PR TITLE
Align scraper UI with ADXS builder layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,33 +1,109 @@
 # ADXS Knowledge Scraper Workspace
 
-This repository provides a browser-based interface for collecting structured content from the ADXS.org knowledge base. The tool works entirely in the browser — no server or backend code is required.
+An interactive browser application for harvesting structured content from the ADXS.org knowledge base. The UI combines a sitemap-driven section selector, citation and tooltip validation, custom document assembly, and responsive styling so it stays usable on large desktop monitors and smaller Android screens.
 
-## Getting started
+> **Why a helper server?** ADXS.org does not send permissive CORS headers, so browsers block direct cross-origin `fetch` calls. The included Node helper server proxies requests locally, giving the front-end safe access to the remote HTML.
 
-1. **Open the interface**
-   - Double-click `index.html` or open it in your preferred browser via `File → Open`. Modern Chromium-based browsers work best. If your browser blocks `fetch` requests for local files, launch a lightweight static server (for example `python -m http.server`) from the project directory and visit `http://localhost:8000/index.html`.
+## Prerequisites
 
-2. **Configure the scrape**
-   - The **Base URL** defaults to `https://www.adxs.org`. Update it if you want to target a staging or mirrored host.
-   - Choose a **scraping mode**:
-     - **Single page**: captures only the first path in the list (or the base URL when the list is empty).
-     - **Section crawl**: iterates through every path you provide, optimised for anchor-heavy article sections.
-     - **Batch list**: scrapes each path in sequence and reports progress for multi-page collections.
-   - Supply one relative path per line in the **Paths to scrape** area. Leave the field empty to scrape the base URL.
-   - Toggle capture options for inline citations, tooltip text, and footnotes/endnotes.
+- [Node.js 18+](https://nodejs.org/) (includes `npm` and the global `fetch` API used by the proxy)
+- A modern Chromium- or Firefox-based browser. Chrome/Firefox for Android work well when you follow the mobile guide below.
 
-3. **Run and monitor**
-   - Use **Start** to begin the session. **Pause** temporarily suspends requests; tap **Resume** to continue, or **Stop** to cancel the remainder of the batch.
-   - The progress meter and log tab display active URLs, request outcomes, and any network issues.
-   - The preview tab surfaces key sections from each page, while the statistics tab aggregates counts for sections, citations, tooltips, footnotes, and total words.
+## Guided setup (desktop & laptop)
 
-4. **Work with the results**
-   - Export buttons generate downloads in JSON, Markdown, HTML, and BibTeX formats. Each export reflects the current batch results only.
-   - Use **Copy summary** to place a compact overview of the batch on your clipboard for quick sharing.
-   - All scraped data stays in memory until you refresh the page or start a new session.
+1. **Download the project** – clone the repository or unzip it into a folder on your machine.
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+   This pulls in Express (for the proxy/static server) and its minimal dependency tree.
+3. **Start the helper server**
+   ```bash
+   npm run dev
+   ```
+   Leave this terminal window running. The server listens on [http://localhost:3000](http://localhost:3000), serves the UI, and exposes `/api/fetch` for proxied ADXS requests.
+4. **Open the UI** – visit `http://localhost:3000` in your browser. The blue proxy warning in the configuration panel disappears once the app detects it is being served over HTTP/HTTPS.
 
-## Notes
+## Choosing what to scrape
 
-- Scraping honours the same-origin policy enforced by your browser. If ADXS.org blocks cross-origin requests, run the interface from a local server or consult the network console for troubleshooting tips.
-- Large batches are throttled slightly between requests to keep the site responsive. Adjust the supplied paths to tune throughput.
-- The UI is responsive and adapts to smaller screens, making it suitable for tablet-based reviews.
+- **URL builder** – the blue builder at the top lets you pick a language (`/en` or `/de`), type a relative path, and click **Apply URL** to stage it. The quick chips drop in popular ADXS articles, and the live preview shows the exact target (e.g. `https://www.adxs.org/en/page/560/…`).
+- **Manual paths** – keep extra paths (one per line) in the **Paths to scrape** textarea. The builder appends to this list; choose *Batch URLs* mode if you want every entry processed.
+- **Sitemap selection** – the **Sitemap Selection** panel loads the live site hierarchy via the helper proxy. Tick sections or entire groups before starting a run and they will be merged with the manual list automatically.
+- **Test connection** – the **🔗 Test Connection** button pings the helper server against the staged URL so you can confirm the proxy is running before a long scrape.
+
+## Running a scrape
+
+1. **Scraping mode** – choose between *Single page*, *Section + Related Pages*, *Batch URLs*, or *From Sitemap Selection*. Single mode only processes the first staged path; the others walk every entry.
+2. **Capture options** – toggle inline citations, tooltip text (including `data-tippy-content` popovers), footnotes/endnotes, and extra metadata. Leave them on for the most complete validation.
+3. **Processing options** – enable citation validation, related-link crawling, PDF downloads, and HTML cleaning depending on the batch you are preparing.
+4. **Controls** – click **Start Scraping** to begin. **Pause** temporarily suspends the queue; click again to resume. **Stop** cancels the remaining URLs. The status pill in the header reflects the current state, and the blue progress bar tracks processed pages.
+5. **Monitor progress** – the Results panel exposes multiple tabs:
+   - **Content** – card previews of the first few sections per page.
+   - **Citations** – every inline superscript, including tooltip text and outbound links.
+   - **Structure** – a flat list of captured headings for quick orientation.
+   - **Validation** – the self-check summary (pass/warn/error) with detailed messages.
+   - **Documents** – the section picker and document builder for assembling exports.
+   - **Raw Data / Logs** – the full JSON payload and streaming proxy log.
+   Export buttons across the top enable Markdown/HTML/JSON/BibTeX downloads once a page succeeds.
+
+## Using the sitemap selector
+
+The **Sitemap Selection** panel on the lower half of the page loads the ADXS sitemap so you can curate batches visually:
+
+- Click **Refresh sitemap** whenever you change the base URL or language. Categories expand automatically once data arrives via the helper proxy.
+- Tick the checkboxes next to sections and subsections to add them to the scraping queue. Chips under the summary show the most recent selections.
+- Use the toolbar buttons to select everything, clear the current selection, or expand/collapse category groups. Group-level buttons let you capture or clear one topic cluster at a time.
+- The selections are deduplicated with the manual path list when you click **Start Scraping**.
+
+## Building custom documents
+
+Use the **Documents** tab after a run finishes:
+
+1. Expand a page, tick the sections you want, and repeat across as many pages as required.
+2. Provide a descriptive name and click **Create document from selected sections**. The app stores the document (including metadata, word counts, and originating pages) in memory.
+3. Repeat to build multiple focused packets. Remove a document at any time with the **Remove** button.
+4. Export individual documents as Markdown, HTML, or JSON directly from each card.
+
+Selections persist until you clear them or start a new scraping session. The **Clear selection** button in the tab resets the section checkboxes without deleting existing documents.
+
+## Exporting results
+
+The buttons in the **Results** header generate full-batch exports:
+
+- **JSON** – structured data for downstream scripting.
+- **Markdown / HTML** – human-readable summaries with sections, citations, footnotes, and validation notes.
+- **BibTeX** – quick reference entries for bibliographic tools.
+- **Copy summary** – copies a compact per-page overview (counts plus validation status) to the clipboard.
+
+Exports reflect the current batch in memory. Start a new scrape to reset the dataset.
+
+## Android quick start
+
+You can run the helper server and UI directly on an Android device with [Termux](https://termux.dev/en/):
+
+1. Install Termux from F-Droid or the Termux GitHub releases (the Play Store build is outdated).
+2. Open Termux and install Node.js:
+   ```bash
+   pkg install nodejs-lts git
+   ```
+3. Clone or copy this repository into Termux, then install dependencies:
+   ```bash
+   git clone <your-repo-url>
+   cd <your-repo-folder>
+   npm install
+   ```
+4. Start the helper server:
+   ```bash
+   npm run dev
+   ```
+   Keep Termux in the foreground or run `termux-wake-lock` beforehand to stop Android from suspending the process.
+5. Open Chrome or Firefox on the same device and browse to [http://127.0.0.1:3000](http://127.0.0.1:3000). The layout collapses into a single column, buttons gain larger touch targets, and the sitemap panel remains scrollable with swipe gestures.
+6. When you are finished, switch back to Termux and press `Ctrl+C` to stop the server.
+
+## Troubleshooting
+
+- **“Start the helper server…” warning** – you opened `index.html` directly. Run `npm run dev` and reload via `http://localhost:3000` (or `http://127.0.0.1:3000` on Android).
+- **Sitemap fails to load** – the helper server is required. Ensure it is running, refresh the sitemap, and confirm the terminal logs proxy requests.
+- **Fetch errors or 403s** – verify the helper server output, confirm the target URLs are valid, and respect ADXS.org’s rate limits.
+- **Missing tooltips in validation** – keep the “Tooltip text” option enabled; the validator expects `data-tippy-content` captures to link inline citations with their popover text.
+- **Large batches** – the scraper inserts a short 250 ms delay between requests to avoid overwhelming ADXS.org. Adjust your path list and sitemap selection to control throughput.

--- a/index.html
+++ b/index.html
@@ -3,159 +3,309 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ADXS Knowledge Scraper</title>
+  <title>ADXS.org Production Web Scraper</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header class="app-header">
-    <div class="branding">
-      <h1>ADXS Knowledge Scraper</h1>
-      <p>Harvest sections, citations, tooltips, and footnotes from ADXS.org content for downstream analysis.</p>
-    </div>
-    <div class="header-meta">
-      <span class="badge">v1.0</span>
-      <span class="status-pill" id="statusPill">Idle</span>
-    </div>
-  </header>
+  <div class="container">
+    <header class="header">
+      <h1>
+        ADXS.org Production Web Scraper
+        <span class="adxs-badge">SPECIALIZED</span>
+      </h1>
+      <p>Advanced scraper tailored for the ADXS.org structure, citations, tooltips, and content patterns.</p>
+      <div class="status-bar">
+        <div class="status-indicator status-ready" id="statusIndicator" role="status" aria-live="polite">
+          ● Ready to Scrape
+        </div>
+        <div id="progressContainer" class="hidden" aria-hidden="true">
+          <div class="progress-bar" aria-hidden="true">
+            <div class="progress-fill" id="progressFill"></div>
+          </div>
+          <span id="progressText">0%</span>
+        </div>
+        <div id="scrapingStats" class="hidden" aria-hidden="true">
+          Pages: <span id="pagesScraped">0</span> ·
+          Citations: <span id="citationsFound">0</span> ·
+          Sections: <span id="sectionsFound">0</span>
+        </div>
+      </div>
+    </header>
 
-  <main class="app-layout">
-    <section class="panel configuration" aria-labelledby="configuration-heading">
+    <main class="main-grid">
+      <section class="panel configuration" aria-labelledby="configuration-heading">
+        <div class="panel-header">
+          <h2 id="configuration-heading">⚙️ ADXS Configuration</h2>
+          <p>Define your scraping batch, toggle capture options, and manage the helper proxy.</p>
+        </div>
+        <div class="panel-body">
+          <div class="inline-warning" id="proxyWarning" role="alert" hidden>
+            Live scraping requires the bundled helper server. Run <code>npm install</code> then <code>npm run dev</code> and reload
+            this page from <code>http://localhost:3000</code> (or <code>http://127.0.0.1:3000</code> on Android).
+          </div>
+
+          <div class="adxs-specific">
+            <h3>ADXS.org Optimised Features</h3>
+            <ul>
+              <li>Automatic citation detection linking inline markers to footnotes and tooltips</li>
+              <li>Section anchor extraction and subsection selection</li>
+              <li>Hierarchical sitemap browser for pre-run curation</li>
+              <li>Tooltip harvesting for <code>data-tippy-content</code> popovers</li>
+              <li>PubMed / DOI reference parsing and validation</li>
+              <li>Internal link integrity checks</li>
+            </ul>
+          </div>
+
+          <div class="url-builder" aria-labelledby="url-builder-heading">
+            <div class="url-header">
+              <span class="field-label" id="url-builder-heading">URL Builder</span>
+              <button type="button" class="chip-button" id="applyUrlBtn">Apply URL</button>
+            </div>
+            <div class="url-parts">
+              <span class="url-base">https://www.adxs.org/</span>
+              <select id="languageSelect" aria-label="Language">
+                <option value="en" selected>EN</option>
+                <option value="de">DE</option>
+              </select>
+              <input type="text" id="pathInput" placeholder="page/560/6-guidelines-for-diagnostics" autocomplete="off">
+            </div>
+            <div class="url-target">
+              <strong>Target URL:</strong>
+              <span id="fullUrl">https://www.adxs.org/en/</span>
+            </div>
+            <input type="hidden" id="baseUrl" value="https://www.adxs.org/en">
+            <div class="quick-urls" role="group" aria-label="Quick URLs">
+              <button type="button" class="quick-url" data-path="">Homepage</button>
+              <button type="button" class="quick-url" data-path="sitemap">Sitemap</button>
+              <button type="button" class="quick-url" data-path="page/15/abstract-from-adxsorg">Abstract</button>
+              <button type="button" class="quick-url" data-path="page/560/6-guidelines-for-diagnostics">Diagnostics</button>
+              <button type="button" class="quick-url" data-path="page/180/adhd-treatment-guide">Treatment</button>
+            </div>
+          </div>
+
+          <label class="field" for="scrapingMode">
+            <span class="field-label">Scraping Mode</span>
+            <select id="scrapingMode">
+              <option value="single">Single Page</option>
+              <option value="section">Section + Related Pages</option>
+              <option value="batch">Batch URLs</option>
+              <option value="sitemap">From Sitemap Selection</option>
+            </select>
+          </label>
+
+          <label class="field" id="pathsField">
+            <span class="field-label">Paths to Scrape</span>
+            <textarea id="paths" rows="5" placeholder="page/560/6-guidelines-for-diagnostics&#10;page/180/adhd-treatment-guide"></textarea>
+            <small class="field-hint">Enter one relative path per line. Leave blank to rely entirely on the sitemap selection.</small>
+          </label>
+
+          <fieldset class="field options" aria-labelledby="capture-options-heading">
+            <legend id="capture-options-heading">ADXS Content Extraction</legend>
+            <label class="checkbox-item">
+              <input type="checkbox" id="extractMainContent" checked>
+              <span>Main Content</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="includeCitations" checked>
+              <span>Citations &amp; References</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="extractSections" checked>
+              <span>Section Structure</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="includeTooltips" checked>
+              <span>Tooltip Popovers</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="includeFootnotes" checked>
+              <span>Footnotes &amp; Endnotes</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="extractInternalLinks">
+              <span>Internal Links</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="extractAcknowledgments">
+              <span>Acknowledgments</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="extractMetadata">
+              <span>Page Metadata</span>
+            </label>
+          </fieldset>
+
+          <fieldset class="field options" aria-labelledby="processing-options-heading">
+            <legend id="processing-options-heading">Processing Options</legend>
+            <label class="checkbox-item">
+              <input type="checkbox" id="validateCitations" checked>
+              <span>Validate Citations</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="followInternalLinks" checked>
+              <span>Follow Related Links</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="downloadPDFs">
+              <span>Download PDF References</span>
+            </label>
+            <label class="checkbox-item">
+              <input type="checkbox" id="cleanFormatting" checked>
+              <span>Clean HTML Formatting</span>
+            </label>
+          </fieldset>
+
+          <div class="control-bar">
+            <button type="button" class="btn btn-primary" id="startBtn">▶️ Start Scraping</button>
+            <button type="button" class="btn btn-secondary" id="testConnectionBtn">🔗 Test Connection</button>
+            <button type="button" class="btn btn-warning" id="pauseBtn" disabled>⏸️ Pause</button>
+            <button type="button" class="btn btn-danger" id="stopBtn" disabled>⏹️ Stop</button>
+          </div>
+
+          <div id="batchProgress" class="batch-progress hidden" aria-live="polite">
+            <h4>Batch Progress</h4>
+            <div id="batchList"></div>
+          </div>
+        </div>
+      </section>
+
+      <section class="panel results" aria-labelledby="results-heading">
+        <div class="panel-header results-header">
+          <div>
+            <h2 id="results-heading">📊 Scraping Results</h2>
+            <p>Preview captured content, monitor validation, and build exportable documents.</p>
+          </div>
+          <div class="exports">
+            <button type="button" class="btn btn-success export" data-export="json">💾 JSON</button>
+            <button type="button" class="btn btn-success export" data-export="markdown">📝 Markdown</button>
+            <button type="button" class="btn btn-success export" data-export="html">🌐 HTML</button>
+            <button type="button" class="btn btn-success export" data-export="citations">📚 Citations</button>
+            <button type="button" class="btn btn-success export" data-export="bibtex">📖 BibTeX</button>
+            <button type="button" class="btn btn-secondary" id="copyClipboard">📋 Copy Summary</button>
+          </div>
+        </div>
+
+        <div class="stats-grid" role="list">
+          <div class="stat-card" role="listitem">
+            <h3 id="statWords">0</h3>
+            <p>Words</p>
+          </div>
+          <div class="stat-card" role="listitem">
+            <h3 id="statCitations">0</h3>
+            <p>Citations</p>
+          </div>
+          <div class="stat-card" role="listitem">
+            <h3 id="statSections">0</h3>
+            <p>Sections</p>
+          </div>
+          <div class="stat-card" role="listitem">
+            <h3 id="statPages">0</h3>
+            <p>Pages</p>
+          </div>
+          <div class="stat-card" role="listitem">
+            <h3 id="statTooltips">0</h3>
+            <p>Tooltip Notes</p>
+          </div>
+          <div class="stat-card" role="listitem">
+            <h3 id="statFootnotes">0</h3>
+            <p>Footnotes</p>
+          </div>
+        </div>
+
+        <div class="loader hidden" id="loader" aria-hidden="true"></div>
+
+        <div class="preview-panel">
+          <div class="preview-tabs" role="tablist">
+            <button type="button" class="preview-tab active" data-tab="content" role="tab" aria-selected="true">Content</button>
+            <button type="button" class="preview-tab" data-tab="citations" role="tab" aria-selected="false">Citations</button>
+            <button type="button" class="preview-tab" data-tab="structure" role="tab" aria-selected="false">Structure</button>
+            <button type="button" class="preview-tab" data-tab="validation" role="tab" aria-selected="false">Validation</button>
+            <button type="button" class="preview-tab" data-tab="documents" role="tab" aria-selected="false">Documents</button>
+            <button type="button" class="preview-tab" data-tab="raw" role="tab" aria-selected="false">Raw Data</button>
+            <button type="button" class="preview-tab" data-tab="logs" role="tab" aria-selected="false">Logs</button>
+          </div>
+          <div class="preview-content">
+            <div class="preview-pane active" id="contentPreview" role="tabpanel">
+              <p class="preview-placeholder">No content scraped yet. Configure your run and click <strong>Start Scraping</strong>.</p>
+            </div>
+            <div class="preview-pane" id="citationsPreview" role="tabpanel" aria-hidden="true">
+              <p class="preview-placeholder">No citations extracted yet.</p>
+            </div>
+            <div class="preview-pane" id="structurePreview" role="tabpanel" aria-hidden="true">
+              <p class="preview-placeholder">No structure captured yet.</p>
+            </div>
+            <div class="preview-pane" id="validationPreview" role="tabpanel" aria-hidden="true">
+              <div class="validation-overview">
+                <div class="validation-status" id="validationStatus">Awaiting results</div>
+                <div class="validation-counts">
+                  <span class="count pass">Pass <strong id="validationPassCount">0</strong></span>
+                  <span class="count warning">Warnings <strong id="validationWarnCount">0</strong></span>
+                  <span class="count error">Errors <strong id="validationErrorCount">0</strong></span>
+                </div>
+              </div>
+              <div class="empty-state" id="validationEmpty">Run a scrape to populate validation results.</div>
+              <ul id="validationList" class="validation-list hidden"></ul>
+            </div>
+            <div class="preview-pane" id="documentsPreview" role="tabpanel" aria-hidden="true">
+              <div class="documents-intro">
+                <p>Select sections from the scraped pages to assemble focused documents. Give each document a clear name so you can export them independently.</p>
+              </div>
+              <div class="empty-state" id="documentsEmpty">Scrape at least one page to unlock section selection.</div>
+              <div id="documentBuilder" class="document-builder hidden"></div>
+              <div class="document-actions hidden" id="documentActions">
+                <label class="field">
+                  <span class="field-label">Document name</span>
+                  <input type="text" id="documentName" placeholder="e.g. Diagnostics overview">
+                </label>
+                <div class="document-buttons">
+                  <button type="button" class="btn btn-primary" id="createDocumentBtn">Create document from selected sections</button>
+                  <button type="button" class="btn btn-secondary" id="clearSelectionBtn">Clear selection</button>
+                </div>
+              </div>
+              <div id="documentList" class="document-list hidden"></div>
+            </div>
+            <div class="preview-pane" id="rawPreview" role="tabpanel" aria-hidden="true">
+              <pre id="rawDataOutput" class="raw-output">[]</pre>
+            </div>
+            <div class="preview-pane" id="logsPreview" role="tabpanel" aria-hidden="true">
+              <ul id="logList" class="log-list"></ul>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <section class="panel structure" aria-labelledby="structure-heading">
       <div class="panel-header">
-        <h2 id="configuration-heading">Configuration</h2>
-        <p>Define the scraping batch, select scraping modes, and adjust content capture options.</p>
+        <h2 id="structure-heading">📁 Sitemap Selection</h2>
+        <p>Explore the ADXS sitemap, select sections and subsections, and feed them directly into the scraping queue.</p>
       </div>
-      <div class="panel-body">
-        <label class="field">
-          <span class="field-label">Base URL</span>
-          <input type="url" id="baseUrl" value="https://www.adxs.org" placeholder="https://www.adxs.org" required>
-        </label>
-
-        <div class="field">
-          <span class="field-label">Scraping mode</span>
-          <div class="mode-toggle" role="group" aria-label="Scraping mode">
-            <button type="button" class="mode-button active" data-mode="single">Single page</button>
-            <button type="button" class="mode-button" data-mode="section">Section crawl</button>
-            <button type="button" class="mode-button" data-mode="batch">Batch list</button>
-          </div>
+      <div class="panel-body structure-body">
+        <div class="structure-toolbar" id="structureActions">
+          <button type="button" class="chip-button" data-action="refresh-structure">Refresh sitemap</button>
+          <button type="button" class="chip-button" data-action="select-all">Select all</button>
+          <button type="button" class="chip-button" data-action="clear-selection">Clear selection</button>
+          <button type="button" class="chip-button" data-action="expand-all">Expand all</button>
+          <button type="button" class="chip-button" data-action="collapse-all">Collapse all</button>
         </div>
-
-        <fieldset class="field options" aria-label="Capture options">
-          <legend>Capture options</legend>
-          <label>
-            <input type="checkbox" id="includeCitations" checked>
-            Inline citations
-          </label>
-          <label>
-            <input type="checkbox" id="includeTooltips" checked>
-            Tooltip text
-          </label>
-          <label>
-            <input type="checkbox" id="includeFootnotes" checked>
-            Footnotes &amp; endnotes
-          </label>
-        </fieldset>
-
-        <label class="field">
-          <span class="field-label">Paths to scrape</span>
-          <textarea id="paths" rows="6" placeholder="/wiki/some-article\n/wiki/another-article"></textarea>
-          <small class="field-hint">Enter one relative path per line. Leave blank for the base URL.</small>
-        </label>
-
-        <div class="control-bar">
-          <button type="button" class="control primary" id="startBtn">Start</button>
-          <button type="button" class="control" id="pauseBtn" disabled>Pause</button>
-          <button type="button" class="control" id="stopBtn" disabled>Stop</button>
+        <div class="structure-summary">
+          <p id="structureSummaryLabel">Loading sitemap…</p>
+          <div class="structure-chips" id="structureChips"></div>
         </div>
-
-        <div class="progress-wrapper" aria-live="polite">
-          <div class="progress-bar" id="progressBar"></div>
-          <div class="progress-meta">
-            <span id="progressText">Awaiting configuration</span>
-            <span id="batchCounter">0 / 0</span>
-          </div>
-        </div>
+        <div id="structureStatus" class="structure-status" role="status" hidden></div>
+        <div id="structureTree" class="structure-tree" role="tree" aria-label="ADXS sitemap"></div>
       </div>
     </section>
 
-    <section class="panel results" aria-labelledby="results-heading">
-      <div class="panel-header results-header">
-        <div>
-          <h2 id="results-heading">Results</h2>
-          <p>Preview captured content, monitor statistics, and review the scraping log.</p>
-        </div>
-        <div class="exports">
-          <button type="button" class="export" data-export="json">Export JSON</button>
-          <button type="button" class="export" data-export="markdown">Export Markdown</button>
-          <button type="button" class="export" data-export="html">Export HTML</button>
-          <button type="button" class="export" data-export="bibtex">Export BibTeX</button>
-          <button type="button" class="export" id="copyClipboard">Copy summary</button>
-        </div>
-      </div>
-        <div class="tabs" role="tablist">
-          <button type="button" role="tab" aria-selected="true" aria-controls="previewPane" class="tab active" data-tab="preview">Preview</button>
-          <button type="button" role="tab" aria-selected="false" aria-controls="statsPane" class="tab" data-tab="stats">Statistics</button>
-          <button type="button" role="tab" aria-selected="false" aria-controls="validationPane" class="tab" data-tab="validation">Validation</button>
-          <button type="button" role="tab" aria-selected="false" aria-controls="logsPane" class="tab" data-tab="logs">Logs</button>
-        </div>
-      <div class="tab-panels">
-        <section id="previewPane" class="tab-panel active" role="tabpanel">
-          <div class="empty-state" id="previewEmpty">No pages scraped yet. Start a session to preview content.</div>
-          <div id="previewContent" class="preview-grid" hidden></div>
-        </section>
-        <section id="statsPane" class="tab-panel" role="tabpanel" aria-hidden="true">
-          <dl class="stats-grid">
-            <div>
-              <dt>Pages scraped</dt>
-              <dd id="statPages">0</dd>
-            </div>
-            <div>
-              <dt>Sections captured</dt>
-              <dd id="statSections">0</dd>
-            </div>
-            <div>
-              <dt>Inline citations</dt>
-              <dd id="statCitations">0</dd>
-            </div>
-            <div>
-              <dt>Tooltip notes</dt>
-              <dd id="statTooltips">0</dd>
-            </div>
-            <div>
-              <dt>Footnotes</dt>
-              <dd id="statFootnotes">0</dd>
-            </div>
-            <div>
-              <dt>Total words</dt>
-              <dd id="statWords">0</dd>
-            </div>
-          </dl>
-        </section>
-        <section id="validationPane" class="tab-panel" role="tabpanel" aria-hidden="true">
-          <div class="validation-overview">
-            <div class="validation-status" id="validationStatus">Awaiting results</div>
-            <div class="validation-counts">
-              <span class="count pass">Pass <strong id="validationPassCount">0</strong></span>
-              <span class="count warning">Warnings <strong id="validationWarnCount">0</strong></span>
-              <span class="count error">Errors <strong id="validationErrorCount">0</strong></span>
-            </div>
-          </div>
-          <div class="empty-state" id="validationEmpty">Run a scrape to populate validation results.</div>
-          <ul id="validationList" class="validation-list" hidden></ul>
-        </section>
-        <section id="logsPane" class="tab-panel" role="tabpanel" aria-hidden="true">
-          <ul id="logList" class="log-list"></ul>
-        </section>
-      </div>
-    </section>
-  </main>
+    <footer class="footer">
+      <p>Built for rapid exploration of the ADXS knowledge base. All data remains local until you export it.</p>
+    </footer>
+  </div>
 
-  <footer class="app-footer">
-    <p>Built for rapid exploration of the ADXS knowledge base. All data remains on this device until exported.</p>
-  </footer>
-
+  <div id="toast" class="toast" role="status" aria-live="polite"></div>
   <script src="script.js" defer></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,832 @@
+{
+  "name": "adxs-knowledge-scraper",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "adxs-knowledge-scraper",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.19.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "adxs-knowledge-scraper",
+  "version": "1.0.0",
+  "description": "Interactive ADXS.org scraper UI with local proxy helper",
+  "main": "server.js",
+  "scripts": {
+    "dev": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const ROOT = path.resolve(__dirname || '.');
+
+const DEFAULT_ALLOWED = ['www.adxs.org', 'adxs.org'];
+const allowedHosts = new Set(
+  (process.env.ALLOWED_HOSTS || DEFAULT_ALLOWED.join(','))
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+);
+
+app.use((req, res, next) => {
+  res.setHeader('X-Proxy-By', 'adxs-local-helper');
+  next();
+});
+
+app.get('/api/fetch', async (req, res) => {
+  const target = req.query.url;
+  if (!target) {
+    return res.status(400).json({ error: 'Missing url query parameter.' });
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(target);
+  } catch (error) {
+    return res.status(400).json({ error: 'Invalid URL provided.', details: error.message });
+  }
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    return res.status(400).json({ error: 'Only HTTP(S) protocols are supported.' });
+  }
+
+  if (allowedHosts.size > 0 && !allowedHosts.has(parsed.hostname)) {
+    return res.status(403).json({ error: 'Host not permitted by proxy.', host: parsed.hostname });
+  }
+
+  try {
+    console.log(`[proxy] ${parsed.toString()}`);
+    const response = await fetch(parsed.toString(), {
+      headers: {
+        'User-Agent': 'adxs-scraper/1.0 (+local proxy)'
+      }
+    });
+
+    const text = await response.text();
+    res.status(response.status);
+    res.setHeader('Cache-Control', 'no-store');
+    const contentType = response.headers.get('content-type');
+    if (contentType) {
+      res.setHeader('Content-Type', contentType);
+    } else {
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    }
+    res.send(text);
+  } catch (error) {
+    console.error('[proxy] error', error);
+    res.status(502).json({ error: 'Proxy request failed.', details: error.message });
+  }
+});
+
+app.use(express.static(ROOT));
+
+app.listen(PORT, () => {
+  console.log(`ADXS helper server running on http://localhost:${PORT}`);
+  console.log(`Allowed hosts: ${Array.from(allowedHosts).join(', ') || 'none'}`);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,610 +1,1063 @@
 :root {
-  color-scheme: light dark;
-  --bg-gradient-start: #0f172a;
-  --bg-gradient-end: #1e293b;
-  --panel-bg: rgba(15, 23, 42, 0.75);
-  --panel-border: rgba(148, 163, 184, 0.2);
-  --text-primary: #f8fafc;
-  --text-secondary: #cbd5f5;
-  --accent: #38bdf8;
-  --accent-strong: #0284c7;
-  --success: #22c55e;
-  --warning: #f97316;
-  --danger: #ef4444;
-  --shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
-  font-size: 16px;
+  --bg-gradient-start: #2c5aa0;
+  --bg-gradient-end: #1a365d;
+  --panel-bg: #ffffff;
+  --panel-border: rgba(17, 25, 40, 0.06);
+  --text-primary: #1f2a44;
+  --text-secondary: #4b5d7a;
+  --accent: #2c5aa0;
+  --accent-strong: #17437a;
+  --success: #28a745;
+  --warning: #ffc107;
+  --danger: #dc3545;
+  --neutral: #f8f9fa;
+  --shadow: 0 12px 32px rgba(21, 36, 66, 0.18);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 * {
+  margin: 0;
+  padding: 0;
   box-sizing: border-box;
 }
 
 body {
-  margin: 0;
-  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-  background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
-  color: var(--text-primary);
+  background: linear-gradient(135deg, var(--bg-gradient-start) 0%, var(--bg-gradient-end) 100%);
   min-height: 100vh;
+  padding: 20px;
+  color: var(--text-primary);
+}
+
+.container {
+  max-width: 1600px;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  padding: 2.5rem 1.75rem 2rem;
+  gap: 20px;
 }
 
-h1, h2, h3 {
-  margin: 0 0 0.25rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+.header {
+  background: var(--panel-bg);
+  border-radius: 18px;
+  padding: 28px;
+  box-shadow: var(--shadow);
 }
 
-p {
-  margin: 0;
-  color: var(--text-secondary);
-}
-
-a {
+.header h1 {
+  font-size: 28px;
   color: var(--accent);
-}
-
-a:hover {
-  color: var(--accent-strong);
-}
-
-.app-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-  margin-bottom: 2rem;
-}
-
-.branding p {
-  max-width: 48ch;
-}
-
-.header-meta {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 12px;
+  margin-bottom: 10px;
 }
 
-.badge {
-  background: rgba(56, 189, 248, 0.2);
-  color: var(--accent);
-  padding: 0.35rem 0.75rem;
+.header p {
+  color: var(--text-secondary);
+  max-width: 60ch;
+  line-height: 1.5;
+}
+
+.adxs-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #28a745, #20c997);
+  color: #ffffff;
+  padding: 5px 12px;
   border-radius: 999px;
-  font-size: 0.75rem;
+  font-size: 12px;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.04em;
 }
 
-.status-pill {
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.2);
-  font-weight: 600;
-  font-size: 0.85rem;
+.status-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  align-items: center;
+  margin-top: 18px;
 }
 
-.app-layout {
+.status-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 18px;
+  border-radius: 24px;
+  font-weight: 600;
+  background: #d4edda;
+  color: #155724;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.status-processing {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.status-error {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.main-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 1fr) minmax(340px, 1.6fr);
-  gap: 2rem;
-  flex: 1;
+  grid-template-columns: 420px 1fr;
+  gap: 20px;
+}
+
+@media (max-width: 1200px) {
+  .main-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .panel {
   background: var(--panel-bg);
-  border: 1px solid var(--panel-border);
-  border-radius: 1.5rem;
+  border-radius: 18px;
+  padding: 26px;
   box-shadow: var(--shadow);
-  padding: 1.75rem;
   display: flex;
   flex-direction: column;
-  backdrop-filter: blur(12px);
+  gap: 22px;
 }
 
-.panel-header {
-  margin-bottom: 1.5rem;
+.panel-header h2 {
+  font-size: 20px;
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.panel-header p {
+  color: var(--text-secondary);
+  margin-top: 6px;
+  line-height: 1.5;
 }
 
 .panel-body {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 22px;
+}
+
+.inline-warning {
+  background: #fff3cd;
+  color: #856404;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 193, 7, 0.35);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.adxs-specific {
+  background: linear-gradient(135deg, #e8f5e9 0%, #d4f8d4 100%);
+  border: 1px solid rgba(40, 167, 69, 0.35);
+  border-radius: 14px;
+  padding: 18px;
+}
+
+.adxs-specific h3 {
+  color: #155724;
+  font-size: 16px;
+  margin-bottom: 10px;
+}
+
+.adxs-specific ul {
+  list-style: disc inside;
+  color: #1f2a44;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.url-builder {
+  background: #f0f7ff;
+  border-radius: 14px;
+  border: 1px solid rgba(44, 90, 160, 0.25);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.url-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.url-parts {
+  display: grid;
+  grid-template-columns: auto 68px 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.url-base {
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.url-target {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.quick-urls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.quick-url {
+  padding: 6px 12px;
+  font-size: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(33, 150, 243, 0.35);
+  background: #e3f2fd;
+  color: #1976d2;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.quick-url:hover {
+  background: #bbdefb;
+  transform: translateY(-1px);
 }
 
 .field {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 8px;
 }
 
 .field-label {
-  font-size: 0.95rem;
-  font-weight: 500;
-  color: var(--text-secondary);
+  font-weight: 600;
+  color: var(--text-primary);
 }
 
-.field-hint {
-  color: rgba(226, 232, 240, 0.6);
-  font-size: 0.75rem;
-}
-
-input[type="url"],
-textarea {
+.field input,
+.field select,
+.field textarea {
   width: 100%;
-  padding: 0.75rem 1rem;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.7);
-  color: inherit;
-  font-size: 0.95rem;
+  border: 2px solid #e0e0e0;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 14px;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-input[type="url"]:focus,
-textarea:focus {
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
   outline: none;
-  border-color: rgba(56, 189, 248, 0.8);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(44, 90, 160, 0.15);
 }
 
-textarea {
+.field textarea {
   resize: vertical;
-  min-height: 140px;
+  min-height: 120px;
 }
 
-.mode-toggle {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
-}
-
-.mode-button {
-  padding: 0.65rem 1rem;
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(30, 41, 59, 0.7);
-  color: inherit;
-  font-weight: 500;
-  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-  cursor: pointer;
-}
-
-.mode-button.active {
-  border-color: rgba(56, 189, 248, 0.9);
-  background: rgba(56, 189, 248, 0.2);
-  transform: translateY(-1px);
+.field-hint {
+  font-size: 12px;
+  color: var(--text-secondary);
 }
 
 .options {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.5rem 1rem;
-  border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  padding: 1rem;
-  background: rgba(15, 23, 42, 0.5);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  border: none;
+  padding: 0;
 }
 
-.options label {
+.checkbox-item {
   display: flex;
+  gap: 8px;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
+  padding: 12px;
+  background: #f8f9fa;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 10px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.checkbox-item:hover {
+  background: #eef3ff;
+  border-color: rgba(44, 90, 160, 0.35);
+}
+
+.checkbox-item input {
+  width: 16px;
+  height: 16px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 22px;
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(17, 25, 40, 0.12);
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #2c5aa0 0%, #1a365d 100%);
+  color: #ffffff;
+}
+
+.btn-secondary {
+  background: #f0f0f0;
+  color: var(--text-primary);
+}
+
+.btn-warning {
+  background: #ffc107;
+  color: #212529;
+}
+
+.btn-danger {
+  background: #dc3545;
+  color: #ffffff;
+}
+
+.btn-success {
+  background: #28a745;
+  color: #ffffff;
 }
 
 .control-bar {
   display: flex;
-  gap: 0.75rem;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
-.control {
-  flex: 1;
-  padding: 0.75rem 1rem;
-  border-radius: 0.85rem;
-  border: none;
-  font-weight: 600;
-  background: rgba(30, 41, 59, 0.8);
-  color: inherit;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
+.batch-progress {
+  background: #f8f9fa;
+  border-radius: 12px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-.control.primary {
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 12px 24px rgba(56, 189, 248, 0.25);
-}
-
-.control:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.control:not(:disabled):hover {
-  transform: translateY(-1px);
-}
-
-.progress-wrapper {
-  position: relative;
-  border-radius: 0.85rem;
-  overflow: hidden;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  padding: 0.75rem 1rem;
-}
-
-.progress-bar {
-  position: absolute;
-  inset: 0;
-  width: 0;
-  background: linear-gradient(90deg, rgba(56, 189, 248, 0.25), rgba(56, 189, 248, 0.6));
-  transition: width 0.3s ease;
-}
-
-.progress-meta {
-  position: relative;
+.batch-item {
   display: flex;
   justify-content: space-between;
-  font-size: 0.85rem;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  font-size: 12px;
+}
+
+.batch-status {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.batch-status.pending {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.batch-status.processing {
+  background: #cce5ff;
+  color: #004085;
+}
+
+.batch-status.complete {
+  background: #d4edda;
+  color: #155724;
+}
+
+.batch-status.error {
+  background: #f8d7da;
+  color: #721c24;
 }
 
 .results-header {
-  display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
+  align-items: center;
 }
 
-.exports {
+.results-header .exports {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: flex-end;
-}
-
-.export {
-  padding: 0.55rem 0.85rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(30, 41, 59, 0.7);
-  color: inherit;
-  font-size: 0.85rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease;
-}
-
-.export:hover:not(:disabled) {
-  border-color: rgba(56, 189, 248, 0.8);
-  background: rgba(56, 189, 248, 0.15);
-}
-
-.export:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.tabs {
-  display: inline-flex;
-  padding: 0.35rem;
-  border-radius: 0.85rem;
-  background: rgba(15, 23, 42, 0.5);
-  margin-bottom: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.tab {
-  border: none;
-  background: transparent;
-  color: inherit;
-  font-weight: 500;
-  padding: 0.5rem 1.25rem;
-  border-radius: 0.7rem;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-.tab.active {
-  background: rgba(56, 189, 248, 0.2);
-  color: var(--text-primary);
-}
-
-.tab-panel {
-  display: none;
-}
-
-.tab-panel.active {
-  display: block;
-}
-
-.preview-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 1rem;
-}
-
-.preview-card {
-  border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  padding: 1rem;
-  background: rgba(15, 23, 42, 0.55);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.preview-card header h3 {
-  font-size: 1.05rem;
-}
-
-.preview-card .metadata {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  font-size: 0.75rem;
-  color: rgba(226, 232, 240, 0.7);
-}
-
-.preview-card section {
-  font-size: 0.9rem;
-  line-height: 1.5;
-  color: rgba(226, 232, 240, 0.9);
+  gap: 8px;
 }
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 14px;
 }
 
-.stats-grid dt {
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.6);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+.stat-card {
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  text-align: center;
 }
 
-.stats-grid dd {
-  margin: 0;
-  font-size: 1.85rem;
+.stat-card h3 {
+  font-size: 22px;
+  color: var(--accent);
+  margin-bottom: 6px;
+}
+
+.stat-card p {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.loader {
+  width: 32px;
+  height: 32px;
+  border: 3px solid rgba(0, 0, 0, 0.08);
+  border-top: 3px solid var(--accent);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  align-self: center;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.preview-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 520px;
+}
+
+.preview-tabs {
+  display: flex;
+  border-radius: 12px 12px 0 0;
+  overflow: hidden;
+  background: #f1f3f4;
+}
+
+.preview-tab {
+  flex: 1;
+  padding: 12px;
+  border: none;
+  background: transparent;
   font-weight: 600;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.preview-tab.active {
+  background: #ffffff;
+  color: var(--accent);
+}
+
+.preview-content {
+  background: #ffffff;
+  border-radius: 0 0 12px 12px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-top: none;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 460px;
+}
+
+.preview-pane {
+  display: none;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+  overflow: auto;
+}
+
+.preview-pane.active {
+  display: flex;
+}
+
+.preview-placeholder {
+  text-align: center;
+  color: var(--text-secondary);
+  margin-top: 80px;
+  line-height: 1.6;
+}
+
+.preview-card {
+  border: 1px solid rgba(44, 90, 160, 0.15);
+  border-radius: 12px;
+  padding: 16px;
+  background: #f8fbff;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.preview-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.preview-card h3 {
+  color: var(--accent-strong);
+}
+
+.preview-card .metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.preview-card footer a {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.section-order {
+  font-weight: 600;
+  color: var(--accent-strong);
+  margin-right: 6px;
+}
+
+.section-heading {
+  color: var(--text-secondary);
+}
+
+.citation-preview {
+  border: 1px solid rgba(44, 90, 160, 0.2);
+  border-radius: 10px;
+  padding: 12px;
+  background: #f0f8ff;
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.citation-number {
+  font-weight: 700;
+  color: var(--accent-strong);
+}
+
+.citation-link {
+  color: #1976d2;
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.citation-link:hover {
+  text-decoration: underline;
 }
 
 .validation-overview {
   display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  align-items: center;
 }
 
 .validation-status {
-  border-radius: 0.85rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  padding: 0.75rem 1rem;
+  padding: 8px 16px;
+  border-radius: 999px;
   font-weight: 600;
-  font-size: 1rem;
-  background: rgba(15, 23, 42, 0.55);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  background: #f1f3f5;
+  color: var(--text-secondary);
 }
 
 .validation-status.pass {
-  border-color: rgba(34, 197, 94, 0.45);
-  color: var(--success);
+  background: #d4edda;
+  color: #155724;
 }
 
 .validation-status.warning {
-  border-color: rgba(250, 204, 21, 0.45);
-  color: var(--warning);
+  background: #fff3cd;
+  color: #856404;
 }
 
 .validation-status.error {
-  border-color: rgba(239, 68, 68, 0.45);
-  color: var(--danger);
+  background: #f8d7da;
+  color: #721c24;
 }
 
 .validation-counts {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem 1.25rem;
-  font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.65);
-}
-
-.validation-counts .count strong {
-  margin-left: 0.35rem;
-  color: var(--text-primary);
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
 }
 
 .validation-list {
   list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 10px;
 }
 
 .validation-item {
-  border-radius: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.45);
-  padding: 1rem 1.1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
+  border-radius: 10px;
+  padding: 12px;
+  border-left: 5px solid transparent;
+  background: #f8f9fa;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
 }
 
 .validation-item.pass {
-  border-color: rgba(34, 197, 94, 0.35);
-  background: rgba(34, 197, 94, 0.12);
+  border-left-color: #28a745;
+  background: #e8f5e9;
+  color: #155724;
 }
 
 .validation-item.warning {
-  border-color: rgba(250, 204, 21, 0.35);
-  background: rgba(250, 204, 21, 0.12);
+  border-left-color: #ffc107;
+  background: #fff3cd;
+  color: #856404;
 }
 
 .validation-item.error {
-  border-color: rgba(239, 68, 68, 0.35);
-  background: rgba(239, 68, 68, 0.12);
+  border-left-color: #dc3545;
+  background: #f8d7da;
+  color: #721c24;
 }
 
-.validation-item-header {
+.validation-context {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.document-builder {
   display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 260px;
+  overflow: auto;
 }
 
-.validation-badge {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-  padding: 0.25rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  flex-shrink: 0;
+.doc-source {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  background: #f8f9fa;
+  overflow: hidden;
 }
 
-.validation-item.pass .validation-badge {
-  border-color: rgba(34, 197, 94, 0.55);
-  color: var(--success);
+.doc-source summary {
+  cursor: pointer;
+  padding: 12px 16px;
+  font-weight: 600;
+  color: var(--accent-strong);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
 }
 
-.validation-item.warning .validation-badge {
-  border-color: rgba(250, 204, 21, 0.55);
-  color: var(--warning);
+.doc-meta {
+  display: flex;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
 }
 
-.validation-item.error .validation-badge {
-  border-color: rgba(239, 68, 68, 0.55);
-  color: var(--danger);
+.doc-section-list {
+  padding: 10px 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
-.validation-message {
+.doc-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.doc-section label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  cursor: pointer;
+}
+
+.doc-section label span {
   flex: 1;
-  font-size: 0.9rem;
-  color: var(--text-primary);
 }
 
-.validation-meta {
+.doc-section input {
+  width: 16px;
+  height: 16px;
+}
+
+.document-empty {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.document-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.document-buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  font-size: 0.75rem;
-  color: rgba(226, 232, 240, 0.7);
+  gap: 10px;
 }
 
-.validation-meta .meta-separator {
-  margin: 0 0.25rem;
-  color: rgba(226, 232, 240, 0.45);
-}
-
-.validation-details {
+.document-list {
   display: grid;
-  gap: 0.35rem;
-  font-size: 0.75rem;
-  color: rgba(226, 232, 240, 0.7);
+  gap: 12px;
+  margin-top: 16px;
 }
 
-.validation-details span {
-  display: block;
+.document-card {
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 14px;
+  padding: 16px;
+  background: #f8f9fa;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.log-list {
+.document-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.document-card h3 {
+  font-size: 16px;
+  color: var(--accent-strong);
+}
+
+.document-card .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.doc-section-preview {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  max-height: 360px;
-  overflow-y: auto;
+  gap: 6px;
 }
 
-.log-entry {
-  background: rgba(15, 23, 42, 0.5);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 0.9rem;
-  padding: 0.75rem 1rem;
-  font-size: 0.85rem;
+.doc-section-preview li {
   display: flex;
   justify-content: space-between;
-  gap: 0.75rem;
+  align-items: center;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
 }
 
-.log-entry[data-type="error"] {
-  border-color: rgba(239, 68, 68, 0.35);
-  background: rgba(239, 68, 68, 0.15);
+.doc-section-preview li span {
+  color: var(--accent);
+  margin-left: 8px;
 }
 
-.log-entry[data-type="success"] {
-  border-color: rgba(34, 197, 94, 0.4);
-  background: rgba(34, 197, 94, 0.12);
+.document-card footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
-.log-entry[data-type="warning"] {
-  border-color: rgba(250, 204, 21, 0.35);
-  background: rgba(250, 204, 21, 0.12);
+.document-card footer .control {
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(44, 90, 160, 0.2);
+  background: #ffffff;
+  color: var(--accent-strong);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
 }
 
-.log-entry time {
-  color: rgba(226, 232, 240, 0.6);
-  font-size: 0.75rem;
-  white-space: nowrap;
+.document-card footer .control:hover {
+  background: #edf3ff;
+  transform: translateY(-1px);
 }
 
-.empty-state {
-  padding: 2rem;
+.document-card footer .control[data-action='remove'] {
+  border-color: rgba(220, 53, 69, 0.4);
+  color: #dc3545;
+}
+
+.raw-output {
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 12px;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 16px;
+  border-radius: 10px;
+  overflow: auto;
+  max-height: 400px;
+}
+
+.log-list {
+  list-style: none;
+  font-family: 'Fira Code', 'Courier New', monospace;
+  font-size: 12px;
+  background: #1a1a1a;
+  color: #00ff7b;
+  padding: 12px;
+  border-radius: 12px;
+  height: 100%;
+  max-height: 320px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.log-entry.error {
+  color: #ff6b6b;
+}
+
+.log-entry.warning {
+  color: #ffc107;
+}
+
+.log-entry.info {
+  color: #00bcd4;
+}
+
+.structure {
+  background: var(--panel-bg);
+}
+
+.structure-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.structure-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.structure-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.structure-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.structure-chip {
+  background: #e0ebff;
+  color: var(--accent-strong);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.structure-status {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.structure-tree {
+  background: #f8fbff;
+  border: 1px solid rgba(44, 90, 160, 0.2);
+  border-radius: 12px;
+  padding: 12px;
+  max-height: 400px;
+  overflow: auto;
+}
+
+.structure-skeleton {
+  height: 14px;
+  background: linear-gradient(90deg, rgba(44, 90, 160, 0.08), rgba(44, 90, 160, 0.2), rgba(44, 90, 160, 0.08));
+  border-radius: 6px;
+  margin-bottom: 8px;
+  animation: skeletonPulse 1.4s ease-in-out infinite;
+}
+
+@keyframes skeletonPulse {
+  0% {
+    transform: translateX(-30%);
+  }
+  50% {
+    transform: translateX(30%);
+  }
+  100% {
+    transform: translateX(-30%);
+  }
+}
+
+.tree-group {
+  margin-bottom: 12px;
+}
+
+.tree-group summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--accent-strong);
+  margin-bottom: 6px;
+}
+
+.tree-children {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-left: 12px;
+}
+
+.tree-item {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.tree-item input {
+  margin-top: 3px;
+}
+
+.footer {
   text-align: center;
-  border: 1px dashed rgba(148, 163, 184, 0.3);
-  border-radius: 1rem;
-  background: rgba(15, 23, 42, 0.4);
-  color: rgba(226, 232, 240, 0.6);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 13px;
+  line-height: 1.6;
+  padding: 12px 0 20px;
 }
 
-.app-footer {
-  margin-top: 2.5rem;
-  text-align: center;
-  color: rgba(226, 232, 240, 0.6);
-  font-size: 0.85rem;
+.toast {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  padding: 12px 18px;
+  border-radius: 12px;
+  color: #ffffff;
+  font-weight: 600;
+  background: var(--accent);
+  transform: translateX(150%);
+  transition: transform 0.3s ease;
+  z-index: 1200;
+  box-shadow: 0 12px 30px rgba(44, 90, 160, 0.25);
 }
 
-@media (max-width: 1100px) {
+.toast.show {
+  transform: translateX(0);
+}
+
+.toast.success {
+  background: #28a745;
+}
+
+.toast.error {
+  background: #dc3545;
+}
+
+.toast.warning {
+  background: #ffc107;
+  color: #212529;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 768px) {
   body {
-    padding: 2rem 1.5rem 1.5rem;
+    padding: 16px;
   }
 
-  .app-layout {
-    grid-template-columns: 1fr;
+  .panel {
+    padding: 20px;
   }
 
-  .results {
-    order: -1;
-  }
-}
-
-@media (max-width: 640px) {
-  .app-header {
-    flex-direction: column;
-    align-items: flex-start;
+  .preview-tabs {
+    flex-wrap: wrap;
   }
 
-  .exports {
-    width: 100%;
+  .preview-tab {
+    flex: 1 1 45%;
+  }
+
+  .results-header .exports {
     justify-content: flex-start;
   }
 
-  .control-bar {
+  .document-item {
     flex-direction: column;
   }
 
-  .control {
+  .document-item .document-actions {
+    flex-wrap: wrap;
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- redesign the index markup to include the ADXS-themed URL builder, results tabs, and sitemap selection panel
- refresh the global styling for the new blue dashboard, preview cards, document builder, and sitemap skeleton states
- update the scraper controller to drive the builder/test flow, render the new preview panes, and wire validation and document assembly to the revised DOM
- expand the README with guidance on the builder workflow, modes, tabs, and sitemap curation

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68c9efc908848329bfa5c68f96550ea6