### PR TITLE
Add mobile-friendly support and beginner guide

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,0 +1,93 @@
+# ADXS Knowledge Scraper – Quick Start Guide
+
+This guide walks through the minimum steps to get the scraper running on Windows, macOS, Linux, or an Android phone. It assumes no prior developer experience and favours copy‑and‑paste commands.
+
+---
+
+## 1. What you need
+
+| Platform | Requirements |
+| --- | --- |
+| Desktop / Laptop | • Internet connection<br>• [Node.js 18 or newer](https://nodejs.org/en/download)<br>• Git (optional but recommended) |
+| Android phone | • Free space for the app data<br>• [Termux](https://f-droid.org/en/packages/com.termux/) from F-Droid or GitHub releases (avoid the outdated Play Store build)<br>• Stable Wi‑Fi or mobile data |
+
+> **Why Node.js?** It lets the helper server proxy requests to ADXS.org so the browser can fetch data safely.
+
+---
+
+## 2. One-time setup
+
+### Option A – Desktop or laptop
+
+1. **Install Node.js**
+   - Windows: download the installer, run it, and keep the default options.
+   - macOS: download the `.pkg` installer or install via [Homebrew](https://brew.sh/) with `brew install node`.
+   - Linux: use your package manager (`sudo apt install nodejs npm` on Ubuntu) or the NodeSource installer.
+2. **Download the project**
+   - Using Git: `git clone <repository-url>`
+   - Manual download: click **Code → Download ZIP**, extract the archive, and open a terminal in the extracted folder.
+3. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+### Option B – Android phone with Termux
+
+1. Install Termux and open it. Allow storage permissions when prompted.
+2. Update the package index and install Node.js and Git:
+   ```bash
+   pkg upgrade
+   pkg install nodejs git
+   ```
+3. Clone the project (or copy it to Termux storage):
+   ```bash
+   git clone <repository-url>
+   cd Adxsall
+   npm install
+   ```
+
+> **Tip:** Termux stores files under `/data/data/com.termux/files/home`. Use `termux-open` to launch a browser from Termux if needed.
+
+---
+
+## 3. Start the helper server
+
+Run the same command on every platform:
+
+```bash
+npm run dev
+```
+
+- The server listens on <http://localhost:3000>.
+- It also binds to `0.0.0.0`, so other devices on the same network can connect using your machine’s IP address (for example `http://192.168.1.24:3000`).
+- Leave this terminal window open; press `Ctrl+C` (or long-press Volume Down + C in Termux) to stop it when finished.
+
+---
+
+## 4. Use the web app
+
+1. Open a modern browser (Chrome, Firefox, Edge, Brave, etc.).
+2. Visit the address the terminal printed—usually <http://localhost:3000> on the device running the server.
+3. If you are on another device (e.g. your Android phone while the server runs on your laptop), type the laptop’s IP address and port 3000 into the phone’s browser.
+4. Configure your scrape and click **Start**.
+
+The interface automatically adapts to small screens. Swipe across the tab bar if it overflows on narrow displays.
+
+---
+
+## 5. Troubleshooting for beginners
+
+| Symptom | What to try |
+| --- | --- |
+| Browser shows a “Start the helper server” warning | The server is not running or you opened `index.html` directly. Return to the terminal and run `npm run dev` again. |
+| Phone cannot reach the server on a laptop | Make sure both devices share the same Wi‑Fi network. Use `ipconfig` (Windows) or `ifconfig`/`ip a` (macOS/Linux) to find the laptop IP, then browse to `http://<that-ip>:3000`. |
+| `npm install` fails in Termux | Update Termux first with `pkg upgrade`. Ensure you have at least 200 MB free space. |
+| “Host not permitted by proxy” error | Only ADXS.org is allowed by default. To permit another domain, set `ALLOWED_HOSTS=my.domain.com` before `npm run dev`. |
+
+---
+
+## 6. Keeping your data
+
+Everything stays on the device running the browser until you export it. Use the **Results → Export** buttons to download JSON, Markdown, HTML, or BibTeX bundles. Remember to copy the exported files out of Termux storage if you are using an Android phone.
+
+Happy scraping!

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ An interactive browser application for harvesting structured content from the AD
 
 > **Why a helper server?** ADXS.org does not send permissive CORS headers, so browsers block direct cross-origin `fetch` calls. The included Node helper server proxies requests locally, giving the front-end safe access to the remote HTML.
 
+If you are just getting started, follow the [Quick Start Guide](GUIDE.md) for beginner-friendly setup instructions on Windows, macOS, Linux, and Android (Termux).
+
 ## Prerequisites
 
 - [Node.js 18+](https://nodejs.org/) (includes `npm` and the global `fetch` API used by the proxy)
@@ -23,7 +25,9 @@ This step pulls in Express (for the proxy/static server) and its small dependenc
 npm run dev
 ```
 
-The server listens on [http://localhost:3000](http://localhost:3000), serves the UI assets, and exposes `/api/fetch` for proxied ADXS requests. Leave this terminal window running while you use the app.
+The server listens on [http://localhost:3000](http://localhost:3000), serves the UI assets, and exposes `/api/fetch` for proxied ADXS requests. It binds to all local interfaces, so you can also reach it from other devices on your network by replacing `localhost` with your machine's IP address. Leave this terminal window running while you use the app.
+
+> **Mobile tip:** Termux on Android can run the helper server directly on your phone. The interface is fully responsive and supports narrow screens.
 
 ## 3. Open the UI
 

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const HOST = process.env.HOST || '0.0.0.0';
 const ROOT = path.resolve(__dirname || '.');
 
 const DEFAULT_ALLOWED = ['www.adxs.org', 'adxs.org'];
@@ -119,7 +120,11 @@ app.get('/api/sitemap', async (req, res) => {
 
 app.use(express.static(ROOT));
 
-app.listen(PORT, () => {
-  console.log(`ADXS helper server running on http://localhost:${PORT}`);
+app.listen(PORT, HOST, () => {
+  const displayedHost = HOST === '0.0.0.0' || HOST === '::' ? 'localhost' : HOST;
+  console.log(`ADXS helper server running on http://${displayedHost}:${PORT}`);
+  if (HOST === '0.0.0.0' || HOST === '::') {
+    console.log('Tip: Share this server with other devices on your network using your machine\'s IP address.');
+  }
   console.log(`Allowed hosts: ${Array.from(allowedHosts).join(', ') || 'none'}`);
 });

--- a/styles.css
+++ b/styles.css
@@ -928,9 +928,36 @@ textarea {
     align-items: flex-start;
   }
 
+  .header-meta {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  body {
+    padding: 1.75rem 1.25rem 1.5rem;
+  }
+
+  .panel {
+    padding: 1.5rem;
+  }
+
   .exports {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .tabs {
+    width: 100%;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tab {
+    flex: 0 0 auto;
   }
 
   .control-bar {
@@ -941,11 +968,61 @@ textarea {
     width: 100%;
   }
 
+  .progress-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
   .document-actions {
     grid-template-columns: 1fr;
   }
 
   .document-actions .control {
     width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 1.5rem 1rem 1.25rem;
+  }
+
+  .app-header {
+    gap: 0.75rem;
+  }
+
+  .panel {
+    padding: 1.25rem;
+    border-radius: 1.25rem;
+  }
+
+  .mode-toggle {
+    grid-template-columns: 1fr;
+  }
+
+  .results-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .exports {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .export {
+    width: 100%;
+    text-align: center;
+  }
+
+  textarea {
+    min-height: 120px;
+  }
+
+  .sitemap-tree {
+    max-height: 45vh;
   }
 }


### PR DESCRIPTION
## Summary
- bind the helper server to 0.0.0.0 by default and document how to share it with other devices
- add responsive layout refinements for narrow screens so the UI is comfortable on Android
- introduce a layman-friendly GUIDE.md and link it from the README with mobile tips

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ce6bb1c04c83299b1e13f522d6f9c2