### PR TITLE
Add workspace context dump tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ The buttons in the **Results** header generate full-batch exports:
 
 Exports reflect the current batch in memory. Start a new scrape to reset the dataset.
 
+## 8. Capture a workspace context snapshot
+
+Generate a Markdown dump of the project (including recent Git metadata and the contents of each source file) with:
+
+```bash
+npm run dump:context
+```
+
+The script writes to `context-dump.md` in the project root and records the generation timestamp, directories it visited, the la
+test `git status --short`, and the last 20 commits from `git log --oneline`.
+
+To keep the export focused on hand-edited assets, the crawler deliberately skips the `.git`, `node_modules`, `dist`, `build`,
+`.next`, `out`, `.cache`, `coverage`, `tmp`, and `logs` directories, along with the generated `context-dump.md` file itself.
+
 ## Troubleshooting
 
 - **“Start the helper server…” warning** – you opened `index.html` directly. Run `npm run dev` and reload via `http://localhost:3000`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Interactive ADXS.org scraper UI with local proxy helper",
   "main": "server.js",
   "scripts": {
-    "dev": "node server.js"
+    "dev": "node server.js",
+    "dump:context": "node tools/dump-context.js"
   },
   "dependencies": {
     "express": "^4.19.2"

--- a/tools/dump-context.js
+++ b/tools/dump-context.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+
+const execFileAsync = promisify(execFile);
+const ROOT_DIR = process.cwd();
+const OUTPUT_FILE = path.join(ROOT_DIR, 'context-dump.md');
+const EXCLUDED_DIRECTORIES = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  '.next',
+  'out',
+  '.cache',
+  'coverage',
+  'tmp',
+  'logs'
+]);
+const EXCLUDED_FILES = new Set([
+  path.basename(OUTPUT_FILE)
+]);
+
+async function getGitSection(title, command, args) {
+  try {
+    const { stdout } = await execFileAsync(command, args, { cwd: ROOT_DIR });
+    const content = stdout.trim();
+    return { title, content: content.length ? content : '[no output]' };
+  } catch (error) {
+    return { title, content: `Error executing ${command} ${args.join(' ')}: ${error.message}` };
+  }
+}
+
+async function walkDirectory(startDir, visitedDirs, files) {
+  const entries = await fs.promises.readdir(startDir, { withFileTypes: true });
+
+  visitedDirs.add(path.relative(ROOT_DIR, startDir) || '.');
+
+  for (const entry of entries) {
+    const entryPath = path.join(startDir, entry.name);
+    const relativePath = path.relative(ROOT_DIR, entryPath);
+
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      await walkDirectory(entryPath, visitedDirs, files);
+    } else if (entry.isFile()) {
+      if (EXCLUDED_FILES.has(entry.name)) {
+        continue;
+      }
+      const stats = await fs.promises.stat(entryPath);
+      let buffer;
+      try {
+        buffer = await fs.promises.readFile(entryPath);
+      } catch (error) {
+        files.push({
+          relativePath,
+          size: stats.size,
+          isBinary: true,
+          error: `Error reading file: ${error.message}`
+        });
+        continue;
+      }
+
+      const isBinary = buffer.includes(0);
+      files.push({
+        relativePath,
+        size: stats.size,
+        isBinary,
+        contents: isBinary ? undefined : buffer.toString('utf8')
+      });
+    }
+  }
+}
+
+async function generateContextDump() {
+  const visitedDirs = new Set();
+  const files = [];
+
+  await walkDirectory(ROOT_DIR, visitedDirs, files);
+
+  const gitStatus = await getGitSection('git status --short', 'git', ['status', '--short']);
+  const gitLog = await getGitSection('git log --oneline -n 20', 'git', ['log', '--oneline', '-n', '20']);
+
+  files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  const sortedDirs = Array.from(visitedDirs).sort();
+
+  const writeStream = fs.createWriteStream(OUTPUT_FILE, { encoding: 'utf8' });
+
+  const writeLine = (line = '') => {
+    writeStream.write(line + '\n');
+  };
+
+  writeLine('# Workspace Context Dump');
+  writeLine();
+  writeLine(`- Generated at: ${new Date().toISOString()}`);
+  writeLine(`- Root directory: ${ROOT_DIR}`);
+  writeLine(`- Output file: ${path.relative(ROOT_DIR, OUTPUT_FILE)}`);
+  writeLine();
+  writeLine('## Git Metadata');
+  writeLine();
+  for (const section of [gitStatus, gitLog]) {
+    writeLine(`### ${section.title}`);
+    writeLine();
+    writeLine('```');
+    writeLine(section.content);
+    writeLine('```');
+    writeLine();
+  }
+
+  writeLine('## Traversed Directories');
+  writeLine();
+  for (const dir of sortedDirs) {
+    writeLine(`- ${dir}`);
+  }
+  writeLine();
+
+  writeLine('## File Contents');
+  writeLine();
+
+  for (const file of files) {
+    writeLine('---');
+    writeLine(`### File: ${file.relativePath}`);
+    writeLine();
+    writeLine(`- Size: ${file.size} bytes`);
+    writeLine();
+    if (file.error) {
+      writeLine(`_Unable to read file. ${file.error}_`);
+    } else if (file.isBinary) {
+      writeLine('_Binary file contents omitted._');
+    } else {
+      writeLine('```text');
+      writeLine(file.contents || '');
+      writeLine('```');
+    }
+    writeLine();
+  }
+
+  await new Promise((resolve, reject) => {
+    writeStream.on('error', reject);
+    writeStream.end(resolve);
+  });
+
+  console.log(`Context dump generated at ${OUTPUT_FILE}`);
+}
+
+generateContextDump().catch((error) => {
+  console.error('Failed to generate context dump:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a Node-based exporter that captures git metadata and file contents into context-dump.md
- provide an npm script for generating the workspace dump on demand
- document how to generate the snapshot and which directories are excluded

## Testing
- npm run dump:context


------
https://chatgpt.com/codex/tasks/task_e_68ce6ffa19a88329b064a67a15980043