### PR TITLE
Include logs in context dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ The script writes to `context-dump.md` in the project root and records the gener
 test `git status --short`, and the last 20 commits from `git log --oneline`.
 
 To keep the export focused on hand-edited assets, the crawler deliberately skips the `.git`, `node_modules`, `dist`, `build`,
-`.next`, `out`, `.cache`, `coverage`, `tmp`, and `logs` directories, along with the generated `context-dump.md` file itself.
+`.next`, `out`, `.cache`, `coverage`, and `tmp` directories, along with the generated `context-dump.md` file itself. The `logs/`
+tree is now included in the crawl so recent helper output is preserved in the snapshot; set the environment variable
+`DUMP_CONTEXT_INCLUDE_LOGS=false` if you prefer to exclude it again.
 
 ## Troubleshooting
 

--- a/tools/dump-context.js
+++ b/tools/dump-context.js
@@ -8,6 +8,8 @@ const { promisify } = require('util');
 const execFileAsync = promisify(execFile);
 const ROOT_DIR = process.cwd();
 const OUTPUT_FILE = path.join(ROOT_DIR, 'context-dump.md');
+const INCLUDE_LOGS = process.env.DUMP_CONTEXT_INCLUDE_LOGS !== 'false';
+
 const EXCLUDED_DIRECTORIES = new Set([
   '.git',
   'node_modules',
@@ -17,9 +19,12 @@ const EXCLUDED_DIRECTORIES = new Set([
   'out',
   '.cache',
   'coverage',
-  'tmp',
-  'logs'
+  'tmp'
 ]);
+
+if (!INCLUDE_LOGS) {
+  EXCLUDED_DIRECTORIES.add('logs');
+}
 const EXCLUDED_FILES = new Set([
   path.basename(OUTPUT_FILE)
 ]);


### PR DESCRIPTION
## Summary
- include logs/ in the dump-context traversal by default while allowing it to be disabled via DUMP_CONTEXT_INCLUDE_LOGS
- document the new default and opt-out environment variable in the README

## Testing
- npm run dump:context

------
https://chatgpt.com/codex/tasks/task_e_68ce7f2f7d10832982325d35af6f1e39